### PR TITLE
feat: dash in security classification/handling instruction

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
           </span>
         </a>
         <span class="govuk-header__security-classification"><strong class="govuk-tag govuk-tag--red">
-          OFFICIAL SENSITIVE
+          OFFICIAL-SENSITIVE
         </strong></span>
       </div>
     </div>


### PR DESCRIPTION
Ah apparently missed that usually there is a dash, not a space