### PR TITLE
feat: red border

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,14 @@
       }
     }
 
+    .govuk-header__container,
+    .govuk-header--full-width-border {
+      border-bottom: 8px solid #e52d13; /* The red is fairly strong, so we make it thinner */
+    }
+    .govuk-header--full-width-border {
+      padding-bottom: 2px;
+    }
+
     .scl-key-info-banner {
       border-bottom: 1px solid #b1b4b6;
       background-color: #f8f8f8;


### PR DESCRIPTION
The red is the department's official colour, which by and large we should be using anyway. And, this distinguishes it from the more generic GOV.UK look