### PR TITLE
infra: enforce a specific HTTP header and value from CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ AWS infrastructure for running the strategic-companies-list is defined through T
     }
 
     output "strategic_companies_list" {
-      value = module.strategic_companies_list
+      value     = module.strategic_companies_list
+      sensitive = true
     }
     ```
 

--- a/infra/Ω-output.tf
+++ b/infra/Ω-output.tf
@@ -1,3 +1,7 @@
 output "lb_alias" {
   value = "You must make sure that '${var.domain_name}' has an ALIAS record (or similar) pointing to '${aws_lb.main.dns_name}'"
 }
+
+output "cdn_header" {
+  value = "You must make sure that CloudFront sets the '${random_id.cdn_header_name.hex}' HTTP header to '${random_bytes.cdn_header_value.hex}' (without quotes)"
+}


### PR DESCRIPTION
To make sure that only _our_ CloudFront distribution can communicate with the ALB, as AWS recommend now enforce a HTTP header check.