### PR TITLE
refactor: move to a basic multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,28 @@
-FROM node:23-bookworm-slim
+FROM node:23-bookworm-slim AS static-resources
 
 WORKDIR /app
 
 COPY package.json .
 COPY package-lock.json .
 
-RUN \
-	npm install && \
-	npm install -g local-web-server
+RUN npm install
 
 COPY images ./images
 COPY index.html .
 
-CMD ws --rewrite '/assets/(.*) -> /node_modules/govuk-frontend/dist/govuk/assets/$1' --rewrite '/stylesheets/(.*) -> /node_modules/govuk-frontend/dist/govuk/$1' --rewrite '/javascripts/(.*) -> /node_modules/govuk-frontend/dist/govuk/$1'
+FROM node:23-bookworm-slim
+
+WORKDIR /app
+
+RUN npm install -g local-web-server
+
+# Copy in assets (images and fonts), stylesheets and JavaScript files to where they're expected
+# (Technically copying a bit too much, but a trivial amount and can be tidied later)
+COPY --from=static-resources /app/node_modules/govuk-frontend/dist/govuk/assets ./assets
+COPY --from=static-resources /app/node_modules/govuk-frontend/dist/govuk ./stylesheets
+COPY --from=static-resources /app/node_modules/govuk-frontend/dist/govuk ./javascripts
+
+COPY images ./images
+COPY index.html .
+
+CMD ws


### PR DESCRIPTION
This is so we can have different stages for building the static resources and Python runtime resources - so we can move to Django without having node installed for example.