### PR TITLE
infra: run CodeBuild in our VPC to avoid rate limits

### DIFF
--- a/infra/2-data.tf
+++ b/infra/2-data.tf
@@ -1,5 +1,7 @@
 data "aws_region" "current" {}
 
+data "aws_caller_identity" "current" {}
+
 data "aws_ec2_managed_prefix_list" "cloudfront" {
   name = "com.amazonaws.global.cloudfront.origin-facing"
 }


### PR DESCRIPTION
Also for some reason this also means we have to specific privileged_mode = True, but we didn't have to before.