### PR TITLE
infra: don't pass external domain to Django

### DIFF
--- a/infra/6-ecs.tf
+++ b/infra/6-ecs.tf
@@ -39,12 +39,6 @@ resource "aws_ecs_task_definition" "main" {
           hostPort      = var.container_port
         }
       ],
-      environment = [
-        {
-          name  = "DJANGO_ALLOWED_HOST"
-          value = var.external_domain_name
-        }
-      ],
       secrets = [
         {
           valueFrom = aws_secretsmanager_secret_version.django_secret_key.arn

--- a/scl/settings.py
+++ b/scl/settings.py
@@ -21,7 +21,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Security settings
 
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
-ALLOWED_HOSTS = [os.environ['DJANGO_ALLOWED_HOST']]
+
+# The ALB enforces that requests have the right header, which means we don't have to enforce that
+# here, which also allows requests from the ALB itself as part of its healthcheck
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition


### PR DESCRIPTION
This sets ALLOWED_HOSTS to ["*"] in order for the ALB healthcheck to be able to make requests to the app.

The ALB already enforces that the right host header is sent, and also the ALB enforces that requests can only be sent from our CloudFront distribution, which itself enforces that the right host header is sent, so there are enough layers of projection on the host header, so it should be safe to allow all hosts from Django's point of view.