### PR TITLE
chore: run collectstatic on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ COPY start.sh .
 COPY manage.py .
 COPY scl ./scl
 
+RUN python manage.py collectstatic
+
 USER scl
 
 CMD ["./start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-python manage.py collectstatic
-
 exec parallel --will-cite --line-buffer --jobs 2 --halt now,done=1 ::: \
     "python manage.py runserver 0.0.0.0:8001" \
     "nginx -p /home/scl"


### PR DESCRIPTION
So startup is then faster, more deterministic, and will allow tightening of file permissions later as well