### PR TITLE
perf: compress static assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,9 @@ COPY start.sh .
 COPY manage.py .
 COPY scl ./scl
 
-RUN python manage.py collectstatic
+RUN \
+    python manage.py collectstatic && \
+    find /app/assets/ -type f -exec gzip -k -9 {} \;
 
 USER scl
 


### PR DESCRIPTION
The nginx config already has gzip_static on, and so this means that static assets should be that tiny bit quicker to transfer.