### PR TITLE
fix: disable caching for non-static assets

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -69,6 +69,10 @@ http {
             proxy_max_temp_file_size 0;
             proxy_pass http://127.0.0.1:8001/;
             proxy_http_version 1.1;
+
+            expires 0;
+            add_header Pragma no-cache;
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
         }
     }
 }


### PR DESCRIPTION
Suspect they're getting cached by CloudFront