### PR TITLE
refactor: tidy search code and make reusable

### DIFF
--- a/scl/core/templates/base.html
+++ b/scl/core/templates/base.html
@@ -184,9 +184,6 @@
     .scl-input-with-search-icon {
       padding-left: 30px;
     }
-    .scl-input-with-search-icon {
-
-    }
     .scl-input-search-icon {
       display: block;
       position: relative;
@@ -196,7 +193,6 @@
       height: 2.5rem;
       background: url({% static 'icon-search.svg' %}) no-repeat -3px center;
     }
-
     .scl-company-list {
       display: flex;
       flex-wrap: wrap;
@@ -204,6 +200,12 @@
     .scl-company-list > li {
       flex: 0 0 33.33333%;
       padding-bottom: 3px;
+    }
+    .scl-company-search-no-results-element {
+      display: none;
+    }
+    .scl-company-search-no-results-element.scl-company-search-no-results {
+      display: block;
     }
 
     .scl-hide-block-on-mobile {

--- a/scl/core/templates/index.html
+++ b/scl/core/templates/index.html
@@ -97,12 +97,12 @@
         Search for a company by its name
       </label>
       <span class="scl-input-search-icon"></span>
-      <input class="govuk-input scl-input-with-search-icon" id="company-name" name="companyName" type="text">
+      <input class="govuk-input scl-input-with-search-icon" data-module="scl-filter-list" data-scl-filter-list-target="#scl-company-list" data-scl-filter-list-no-results="#scl-company-search-no-results" name="companyName" type="text">
     </div>
 
-    <p id="company-name-search-error" class="govuk-body" style="display: none">No companies found</p>
+    <p id="scl-company-search-no-results" class="govuk-body scl-company-search-no-results-element scl-company-search-has-results">No companies found</p>
 
-    <ul class="govuk-list scl-company-list" id="company-list">
+    <ul class="govuk-list scl-company-list" id="scl-company-list">
       <li><a class="govuk-link govuk-link--no-visited-state" href="/company-briefing?company=Apex Group&owned=true">Apex Group</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="/company-briefing?company=Apex Dynamics&owned=false">Apex Dynamics</a></li>
       <li><a class="govuk-link govuk-link--no-visited-state" href="/company-briefing?company=Apex Industries&owned=false">Apex Industries</a></li>
@@ -158,28 +158,34 @@
 </div>
 
 <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    const companyNameInput = document.getElementById("company-name");
-    const companyList = document.getElementById("company-list");
-    const error = document.getElementById("company-name-search-error");
-    companyNameInput.addEventListener("input", () => {
-      // We show companies where every lowercased word in the search string is contained in
-      // the lowercased and space-removed company name. This allows a good range of both "full"
-      // and "quick" searches, e.g. "quantum holdings", "quantumholdings" and "quan hold" all
-      // match "Quantum Holdings", but the number of incorrect matches is very likely to be low
-      const segmenter = new Intl.Segmenter([], { granularity: 'word' });
-      const segmentedText = segmenter.segment(companyNameInput.value);
-      const words = [...segmentedText].filter(s => s.isWordLike).map(s => s.segment);
-      let totalMatched = 0;
+  (() => {
+    const registerFilterList = (input) => {
+      const list = document.querySelector(input.getAttribute("data-scl-filter-list-target"));
+      const noResults = document.querySelector(input.getAttribute("data-scl-filter-list-no-results"));
 
-      Array.from(companyList.children).forEach((child) => {
-        const allWordsMatch = words.every((word) => child.textContent.replace(/\s/g,'').toLocaleLowerCase("en-GB").includes(word.toLocaleLowerCase("en-GB")))
+      input.addEventListener("input", () => {
+        // We show results where every lowercased word in the search string is contained in
+        // the lowercased and space-removed company name. This allows a good range of both "full"
+        // and "quick" searches, e.g. "quantum holdings", "quantumholdings" and "quan hold" all
+        // match "Quantum Holdings", but the number of incorrect matches is very likely to be low
+        const segmenter = new Intl.Segmenter([], { granularity: 'word' });
+        const segmentedText = segmenter.segment(input.value);
+        const words = [...segmentedText].filter(s => s.isWordLike).map(s => s.segment);
+        let totalMatched = 0;
 
-        child.style.display = allWordsMatch ? null : 'none';
-        if (allWordsMatch) totalMatched += 1;
+        Array.from(list.children).forEach((child) => {
+          const allWordsMatch = words.every((word) => child.textContent.replace(/\s/g,'').toLocaleLowerCase("en-GB").includes(word.toLocaleLowerCase("en-GB")))
+
+          child.style.display = allWordsMatch ? null : 'none';
+          if (allWordsMatch) totalMatched += 1;
+        });
+        noResults.classList.toggle('scl-company-search-no-results', !totalMatched);
       });
-      error.style.display = totalMatched ? 'none' : null;
+    };
+
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll('[data-module="scl-filter-list"]').forEach(registerFilterList);
     });
-});
+  })();
 </script>
 {% endblock %}


### PR DESCRIPTION
There isn't a current plan to reuse the search code in multiple places. However, there is a plan to move the transcription code to the front page, and in multiple places. Since that's chunkier, doing this smaller version version as a setting stone/POC to see how it feels and works.