### PR TITLE
refactor: support multiple transcription buttons on page + different styles

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,7 +1,8 @@
 import { TranscribeStreamingClient, StartStreamTranscriptionCommand } from "@aws-sdk/client-transcribe-streaming";
 import { Readable } from 'readable-stream'
 
-document.addEventListener("DOMContentLoaded", () => {
+(() => {
+  // One client shared with all buttons
   const client = new TranscribeStreamingClient({
     region: "eu-west-2",
     credentials: (async function() {
@@ -15,96 +16,107 @@ document.addEventListener("DOMContentLoaded", () => {
     })
   });
 
-  const recordButton = document.getElementById("record");
-  const finalOutput = document.getElementById("final-output");
-  const partialOutput = document.getElementById("partial-output");
-
-
-  let isRecording = false;
-
-  // var processor = null;
-  var stream = null;
-
-  async function stopRecording() {
-    isRecording = false;
-    recordButton.classList.toggle('scl-ready-to-record', !isRecording);
-    recordButton.classList.toggle('scl-recording', isRecording);
-    partialOutput.classList.toggle('scl-recording', isRecording);
-    // audioContext.suspend();
-
-    // if (processor && input) input.disconnect(procesor);
-    // After a few seconds, removes the recording icon(s) from the browser UI
-    stream.getTracks()[0].stop();
+  const htmlToNodes = (html) => {
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    return template.content.childNodes;
   }
 
-  async function startRecording() {
-    isRecording = true;
-    recordButton.classList.toggle('scl-ready-to-record', !isRecording);
-    recordButton.classList.toggle('scl-recording', isRecording);
-    partialOutput.classList.toggle('scl-recording', isRecording);
+  const registerTranscriptionButton = (recordButton) => {
+    const target = document.querySelector(recordButton.getAttribute("data-scl-transcription-target"));
 
-    const audioContext = new AudioContext({sampleRate: 16000});
-    stream = await navigator.mediaDevices.getUserMedia({
-      audio: true,
-      video: false,
-    });
-    const input = audioContext.createMediaStreamSource(stream);
-    const processor = audioContext.createScriptProcessor(1024, 1, 1);
-    input.connect(processor);
-    processor.connect(audioContext.destination);
+    target.replaceChildren(...htmlToNodes('<span class="final-output"></span><span class="partial-output">&nbsp;</span>'))
+    const finalOutput = target.querySelector('.final-output');
+    const partialOutput = target.querySelector('.partial-output');
 
-    const readableStream = Readable();
+    let isRecording = false;
+    var stream = null;
 
-    processor.onaudioprocess = (e) => {
-        const float32Array = e.inputBuffer.getChannelData(0);
-        const int16Array = new Int16Array(float32Array.length);
-        for (let i = 0; i < float32Array.length; i++) {
-          int16Array[i] = float32Array[i] < 0 ? (float32Array[i] * 0x8000) : (float32Array[i] * 0x7fff);
+    function setClasses() {
+      recordButton.classList.toggle('scl-ready-to-record', !isRecording);
+      recordButton.classList.toggle('scl-recording', isRecording);
+      partialOutput.classList.toggle('scl-recording', isRecording);
+    }
+
+    async function stopRecording() {
+      isRecording = false;
+      setClasses();
+      // After a few seconds, removes the recording icon(s) from the browser UI
+      stream.getTracks()[0].stop();
+    }
+
+    async function startRecording() {
+      isRecording = true;
+      setClasses();
+      console.log('starting');
+
+      const audioContext = new AudioContext({sampleRate: 16000});
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: false,
+      });
+      const input = audioContext.createMediaStreamSource(stream);
+      const processor = audioContext.createScriptProcessor(1024, 1, 1);
+      input.connect(processor);
+      processor.connect(audioContext.destination);
+
+      const readableStream = Readable();
+
+      processor.onaudioprocess = (e) => {
+          const float32Array = e.inputBuffer.getChannelData(0);
+          const int16Array = new Int16Array(float32Array.length);
+          for (let i = 0; i < float32Array.length; i++) {
+            int16Array[i] = float32Array[i] < 0 ? (float32Array[i] * 0x8000) : (float32Array[i] * 0x7fff);
+          }
+          readableStream.emit('audioData', new Int8Array(int16Array.buffer));
+      };
+
+      const audioStream = async function* () {
+        while (isRecording) {
+          const chunk = await new Promise(resolve => readableStream.once('audioData', resolve));
+          if (chunk === null) break;
+          yield { AudioEvent: { AudioChunk: chunk } };
         }
-        readableStream.emit('audioData', new Int8Array(int16Array.buffer));
-    };
+      };
 
-    const audioStream = async function* () {
-      while (isRecording) {
-        const chunk = await new Promise(resolve => readableStream.once('audioData', resolve));
-        if (chunk === null) break;
-        yield { AudioEvent: { AudioChunk: chunk } };
-      }
-    };
+      const command = new StartStreamTranscriptionCommand({
+        LanguageCode: "en-GB",
+        MediaSampleRateHertz: 16000,
+        MediaEncoding: "pcm",
+        EnablePartialResultsStabilization: true,
+        PartialResultsStability: "low",
+        AudioStream: audioStream(),
+      });
+      const response = await client.send(command);
 
-    const command = new StartStreamTranscriptionCommand({
-      LanguageCode: "en-GB",
-      MediaSampleRateHertz: 16000,
-      MediaEncoding: "pcm",
-      EnablePartialResultsStabilization: true,
-      PartialResultsStability: "low",
-      AudioStream: audioStream(),
-    });
-    const response = await client.send(command);
-
-    for await (const event of response.TranscriptResultStream) {
-      if (event.TranscriptEvent) {
-        const results = event.TranscriptEvent.Transcript.Results;
-        results.forEach((result) => {
-          const transcript = (result.Alternatives || []).map((alternative) => {
-            return alternative.Transcript;
-          })[0];
-          if (result.IsPartial) {
-            partialOutput.innerText = ' ' + transcript;
-          } else {
-            finalOutput.innerText = (finalOutput.innerText || '') + ' ' + transcript;
-            partialOutput.innerText = '';
-          }
-          if (transcript != '') {
-            partialOutput.classList.add("scl-with-text");
-          }
-        });
+      for await (const event of response.TranscriptResultStream) {
+        if (event.TranscriptEvent) {
+          const results = event.TranscriptEvent.Transcript.Results;
+          results.forEach((result) => {
+            const transcript = (result.Alternatives || []).map((alternative) => {
+              return alternative.Transcript;
+            })[0];
+            if (result.IsPartial) {
+              partialOutput.innerText = ' ' + transcript;
+            } else {
+              finalOutput.innerText = (finalOutput.innerText || '') + ' ' + transcript;
+              partialOutput.innerText = '';
+            }
+            if (transcript != '') {
+              partialOutput.classList.add("scl-with-text");
+            }
+          });
+        }
       }
     }
-  }
 
-  recordButton.addEventListener("click", () => {
-    if (isRecording) stopRecording();
-    else startRecording();
+    recordButton.addEventListener("click", () => {
+      if (isRecording) stopRecording();
+      else startRecording();
+    });
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll('[data-module="scl-transcription-button"]').forEach(registerTranscriptionButton);
   });
-});
+})();

--- a/scl/core/templates/engagement.html
+++ b/scl/core/templates/engagement.html
@@ -20,7 +20,7 @@
     <div class="govuk-grid-row scl-no-grid-mobile">
       <div class="govuk-grid-column-one-half">
         <div class="scl-key-info-panel" style="margin-bottom: 20px">
-            <button class="govuk-button scl-record-button scl-ready-to-record" id="record" type="button" style="margin-bottom: 20px">
+            <button class="govuk-button scl-record-button scl-ready-to-record" data-module="scl-transcription-button" data-scl-transcription-target="#transcription-target-1" type="button">
               <span class="scl-start-text">Start recording</span>
               <span class="scl-microphone"><svg width="17" viewbox="0 0 576 700" xmlns="http://www.w3.org/2000/svg" fill="currentColor" style="overflow: visible; margin-left: 5px; margin-bottom: -2px"><path d="M576 348h-72c0 105.84-86.16 192-192 192h-48c-105.84 0-192-86.16-192-192H0c0 141.61 111.94 257.39 252 263.63v96.38H120v72h336v-72H324v-96.38C464.06 605.4 576 489.47 576 348Z"/><path d="M288 480c79.45 0 144-64.55 144-144V144C432 64.55 367.45 0 288 0S144 64.55 144 144v192c0 79.45 64.55 144 144 144zm-72-336c0-39.7 32.3-72 72-72s72 32.3 72 72v192c0 39.7-32.3 72-72 72s-72-32.3-72-72z"/></svg></span>
               </span>
@@ -29,7 +29,7 @@
                 <svg width="18" viewBox="0 0 24 24" fill="currentColor"  xmlns="http://www.w3.org/2000/svg" style="overflow: visible; margin-left: 5px; position: relative; top: 2px"><style>.spinner_7uc5{animation:spinner_3l8F .9s linear infinite;animation-delay:-.9s}.spinner_RibN{animation-delay:-.7s}.spinner_ZAxd{animation-delay:-.5s}@keyframes spinner_3l8F{0%,66.66%{animation-timing-function:cubic-bezier(0.14,.73,.34,1);y:6px;height:12px}33.33%{animation-timing-function:cubic-bezier(0.65,.26,.82,.45);y:1px;height:22px}}</style><rect class="spinner_7uc5 spinner_ZAxd" x="1" y="6" width="2.8" height="12"/><rect class="spinner_7uc5 spinner_RibN" x="5.8" y="6" width="2.8" height="12"/><rect class="spinner_7uc5" x="10.6" y="6" width="2.8" height="12"/><rect class="spinner_7uc5 spinner_RibN" x="15.4" y="6" width="2.8" height="12"/><rect class="spinner_7uc5 spinner_ZAxd" x="20.2" y="6" width="2.8" height="12"/></svg>
               </span>
             </button>
-            <p class="govuk-body"><span id="final-output"></span><span id="partial-output" class="partial-output">&nbsp;</span></p>
+            <p class="govuk-body" id="transcription-target-1"></p>
           </div>
         </div>
       <div class="govuk-grid-column-one-half"></div>


### PR DESCRIPTION
As a step towards multiple transcription buttons on the front page, changing the code that does the transcribing to be slightly more generic, and in keeping with the "data-x=..." attribute pattern used by the company search, and the GOV.UK Design System.