### PR TITLE
infra: configure nginx to log the real IP from CloudFront

### DIFF
--- a/infra/Ω-output.tf
+++ b/infra/Ω-output.tf
@@ -17,3 +17,7 @@ output "_04_alias" {
 output "_05_cdn_header" {
   value = "You must make sure that the CloudFront distribution sets the '${random_id.cdn_header_name.hex}' HTTP header to '${random_bytes.cdn_header_value.hex}' (without quotes)"
 }
+
+output "_06_address_header" {
+  value = "You must make sure that the CloudFront distribution passes the  CloudFront-Viewer-Address header to the load balancer, for example by using the Managed-AllViewerAndCloudFrontHeaders-2022-06 origin request policy"
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,6 +16,10 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # Requires CloudFront to be configured to send this, for example by using the
+    # Managed-AllViewerAndCloudFrontHeaders-2022-06 origin request policy
+    real_ip_header CloudFront-Viewer-Address;
+
     more_set_headers "Server: scl";
 
     client_body_temp_path /tmp/nginx-client-body;


### PR DESCRIPTION
Right now it would be logging the IP from the load balancer, which isn't that helpful