### PR TITLE
fix: tags in mobile view and hide private content

### DIFF
--- a/scl/core/templates/base.html
+++ b/scl/core/templates/base.html
@@ -327,10 +327,9 @@
     .card--private::before {
       font-family: GDS Transport,arial,sans-serif;
       display: block;
+      float: right;
       content: "Privileged";
-      position: absolute;
-      right: 0;
-      top: 0;
+      margin: -15px -15px 0;
       padding: 5px;
       background-color: #e88978;
     }

--- a/scl/core/templates/company.html
+++ b/scl/core/templates/company.html
@@ -33,6 +33,7 @@
               <li>Data Analyst: Mr John Smith, appointed October 2023.</li>
             </ul>
           </div>
+          {% if is_owner == 'true' %}
           <div class="card card--private">
             <h2 class="govuk-heading-m">Company current issues and priorities</h2>
             <ol class="govuk-list govuk-list--number">
@@ -49,6 +50,7 @@
                 <li><b>Growing capabilities.</b> <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</div></li>
               </ol>
           </div>
+          {% endif %}
         </section>
       {% if is_owner == 'true' %}
         <aside class="govuk-grid-column-one-third" role="complementary">


### PR DESCRIPTION
This change updates the privileged tags to not overlap the content when on mobile view. Also this hides some private content if the user isn't an owner.