### PR TITLE
feat: remove logging CloudFoundry trace headers

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -49,9 +49,7 @@ http {
       '"request_time":"$request_time",'
       '"http_referrer":"$http_referer",'
       '"http_user_agent":"$http_user_agent",'
-      '"http_x_amzn_trace_id":"$http_x_amzn_trace_id",'
-      '"http_x_b3_traceid":"$http_x_b3_traceid",'
-      '"http_x_b3_spanid":"$http_x_b3_spanid"'
+      '"http_x_amzn_trace_id":"$http_x_amzn_trace_id"'
     '}';
     access_log /dev/stdout json_combined;
 


### PR DESCRIPTION
We're no longer running in CloudFoundry (and don't plan to).