### PR TITLE
fix: show privileged on mobile

### DIFF
--- a/scl/core/static/scl.css
+++ b/scl/core/static/scl.css
@@ -51,6 +51,21 @@
     display: block;
   }
 }
+.scl-header__security-classification {
+  float: right;
+  margin: 4px 0 0 0;
+}
+.scl-header__security-classification--long {
+  display: none;
+}
+@media (min-width: 48.0625em) {
+  .scl-header__security-classification--long {
+    display: inline;
+  }
+  .scl-header__security-classification--short {
+    display: none;
+  }
+}
 
 .scl-footer {
 }
@@ -61,12 +76,21 @@
 }
 
 .scl-tag {
+  /* A bit smaller than GOV.UK's, but since we capitalise them, it doesn't look smaller */
+  padding: 0 7px 0 7px;
+  font-weight: bold;
+  line-height: 22px;
+  font-size: 0.8rem;
 }
-
-.scl-tag--hanging-under-govuk-section-break {
-}
-
 .scl-tag--security {
+  /* A bit darker than GOV.UK's red so it looks less pink, especially when in the header against
+     a dark background, but it's still AAA-compliant contrast-wise */
+  background: #e88978;
+}
+.scl-tag--hanging {
+  float: right;
+  margin-top: -1px;
+  margin-bottom: 1px; /* So text doesn't get too close underneath */
 }
 
 .scl-tag--date {

--- a/scl/core/templates/base.html
+++ b/scl/core/templates/base.html
@@ -15,31 +15,6 @@
   <link rel="stylesheet" href="{% static 'govuk-frontend.min.css' %}">
   <link rel="stylesheet" href="{% static 'scl.css' %}">
   <style>
-    .govuk-header__security-classification > .govuk-tag {
-      margin: 4px 0 0 0;
-      padding: 0 7px 0 7px;
-      font-weight: bold;
-      float: right;
-      line-height: 22px;
-      font-size: 0.8rem; /* A bit smaller, but since it's capitalised, so doesn't look smaller */
-      background: #e88978; /* A bit darker than default so it looks red in black background */
-    }
-
-    .govuk-header__security-classification__long {
-      display: none;
-    }
-    .govuk-header__security-classification__short {
-      display: inline;
-    }
-    @media (min-width: 40.0625em) {
-      .govuk-header__security-classification__long {
-        display: inline;
-      }
-      .govuk-header__security-classification__short {
-        display: none;
-      }
-    }
-
     .govuk-header__container,
     .govuk-header--full-width-border {
       border-bottom: 8px solid #e52d13; /* The red is fairly strong, so we make it thinner */
@@ -317,12 +292,12 @@
             Strategic Companies List
           </span>
         </a>
-        <span class="govuk-header__security-classification govuk-header__security-classification__long"><strong class="govuk-tag govuk-tag--red">
+        <strong class="govuk-tag govuk-tag--red scl-tag scl-tag--security scl-header__security-classification scl-header__security-classification--long">
           OFFICIAL-SENSITIVE
-        </strong></span>
-        <span class="govuk-header__security-classification govuk-header__security-classification__short"><strong class="govuk-tag govuk-tag--red">
+        </strong>
+        <strong class="govuk-tag govuk-tag--red scl-tag scl-tag--security scl-header__security-classification scl-header__security-classification--short">
           OFF-SEN
-        </strong></span>
+        </strong>
       </div>
     </div>
   </header>

--- a/scl/core/templates/company.html
+++ b/scl/core/templates/company.html
@@ -46,9 +46,7 @@
         </ul>
         {% if is_owner == 'true' %}
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-section-break--visible govuk-!-margin-top-7 govuk-!-margin-bottom-0">
-        <span class="govuk-header__security-classification govuk-header__security-classification__long"><strong class="govuk-tag govuk-tag--red scl-privileged">
-          PRIVILEGED
-        </strong></span>
+        <strong class="govuk-tag govuk-tag--red scl-tag scl-tag--security scl-tag--hanging">PRIVILEGED</strong>
         <h2 class="govuk-heading-m govuk-!-margin-top-3">Company current issues and priorities</h2>
         <ol class="govuk-list govuk-list--number scl-editable">
           <li>
@@ -102,9 +100,7 @@
       {% if is_owner == 'true' %}
       <aside class="govuk-grid-column-one-third" role="complementary">
         <hr class="govuk-section-break govuk-section-break--m govuk-!-margin-top-0 govuk-section-break--visible govuk-!-margin-bottom-0">
-        <span class="govuk-header__security-classification govuk-header__security-classification__long"><strong class="govuk-tag govuk-tag--red scl-privileged">
-          PRIVILEGED
-        </strong></span>
+        <strong class="govuk-tag govuk-tag--red scl-tag scl-tag--security scl-tag--hanging">PRIVILEGED</strong>
         <h2 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">
           Recent top-level engagements across HMG
         </h2>


### PR DESCRIPTION
Although initially a refactor by move the security-related tags to BEM, it had the nice side effect of bringing back privileges on mobile.