### PR TITLE
feat: more padding in date tags on front page

### DIFF
--- a/scl/core/static/scl.css
+++ b/scl/core/static/scl.css
@@ -83,10 +83,30 @@
   line-height: 22px;
   font-size: 0.8rem;
 }
+:focus .scl-tag {
+  background: transparent;
+  outline: 2px dotted #0b0c0c;
+  /* Still a touch close to the left on Desktop */
+  outline-offset: -3px;
+}
+.scl-tag--medium {
+  font-size: 13px;
+  padding: 2px 5px;
+}
+.scl-tag--small {
+  font-size: 11px;
+  padding: 2px 0 0 0;
+  line-height: 15px;
+}
 .scl-tag--security {
   /* A bit darker than GOV.UK's red so it looks less pink, especially when in the header against
      a dark background, but it's still AAA-compliant contrast-wise */
   background: #e88978;
+}
+.scl-tag--date {
+  width: 85px;
+  margin-right: 8px;
+  text-align: center;
 }
 .scl-tag--hanging {
   float: right;
@@ -94,16 +114,26 @@
   margin-bottom: 1px; /* So text doesn't get too close underneath */
 }
 
-.scl-tag--date {
+.scl-list {
 }
+.scl-list__item_header {
+}
+.scl-list__date {
+  margin-right: 8px;
+  position: relative;
+  top: -2px;
+}
+
+.scl-multiline-list__date {
+  position: relative;
+  top: -2px;
+}
+
 
 .scl-key-info {
 }
 
 .scl-key-info__panel {
-}
-
-.scl-key-info__list {
 }
 
 .scl-sidebar {

--- a/scl/core/templates/base.html
+++ b/scl/core/templates/base.html
@@ -141,11 +141,6 @@
     .scl-mobile-list-multiline li {
       border-bottom: none;
     }
-    .scl-mobile-list-multiline .scl-date-tag {
-      font-size: 11px;
-      padding: 2px 0 0 0;
-      width: 85px;
-    }
     .scl-small {
       font-size: 14px;
     }
@@ -239,24 +234,6 @@
     }
     .partial-output.scl-recording {
       border-right: 2px solid #1d70b8;
-    }
-
-    .scl-date-tag {
-      font-size: 13px;
-      margin-right: 8px;
-      position: relative;
-      top: -2px;
-      font-weight: bold;
-      padding: 2px 5px;
-      display: inline-block;
-      width: 85px;
-      text-align: center;
-    }
-    .scl-list-header-link:focus .scl-date-tag {
-      background: transparent;
-      outline: 2px dotted #0b0c0c;
-      /* Still a touch close to the left on Desktop */
-      outline-offset: -3px;
     }
   </style>
 </head>

--- a/scl/core/templates/company.html
+++ b/scl/core/templates/company.html
@@ -107,26 +107,26 @@
         <ul class="govuk-list scl-mobile-list scl-mobile-list-multiline govuk-!-margin-bottom-2">
           <li>
             <a href="#" class="govuk-link govuk-link--no-visited-state scl-list-header-link">
-              <div><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-date-tag">1 Feb. 2025</strong></div>
+              <div><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-tag scl-tag--small scl-tag--date scl-multiline-list__date">1 Feb. 2025</strong></div>
               <span class="scl-block-link-text">UK manufacturing round table</span>
             </a
             >
           </li>
           <li>
             <a href="#" class="govuk-link govuk-link--no-visited-state scl-list-header-link">
-              <div><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-date-tag">23 Jun. 2025</strong></div>
+              <div><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-tag scl-tag--small scl-tag--date scl-multiline-list__date">23 Jun. 2025</strong></div>
               <span class="scl-block-link-text">France meeting</span>
             </a>
           </li>
           <li>
             <a href="#" class="govuk-link govuk-link--no-visited-state scl-list-header-link">
-              <div><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-date-tag">10 Dec. 2024</strong></div>
+              <div><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-tag scl-tag--small scl-tag--date scl-multiline-list__date">10 Dec. 2024</strong></div>
               <span class="scl-block-link-text">Italy meeting</span>
             </a>
           </li>
           <li>
             <a href="#" class="govuk-link govuk-link--no-visited-state scl-list-header-link">
-              <div><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-date-tag">15 Nov. 2024</strong></div>
+              <div><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-tag scl-tag--small scl-tag--date scl-multiline-list__date">15 Nov. 2024</strong></div>
               <span class="scl-block-link-text">Aerospace round table</span>
             </a>
           </li>

--- a/scl/core/templates/index.html
+++ b/scl/core/templates/index.html
@@ -15,7 +15,7 @@
           <ul class="govuk-list scl-mobile-list">
             <li>
               <div class="scl-mobile-list-header">
-                <a class="govuk-link govuk-link--no-visited-state scl-list-header-link" href="#"><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-date-tag">3 Mar. 2025</strong><span class="scl-block-link-text">Synergy Group</span></a>
+                <a class="govuk-link govuk-link--no-visited-state scl-list-header-link" href="#"><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-tag scl-tag--medium scl-tag--date scl-list__date">3 Mar. 2025</strong><span class="scl-block-link-text">Synergy Group</span></a>
                 <button class="govuk-button scl-inline-record-button scl-ready-to-record" type="button" data-module="scl-transcription-button" data-scl-transcription-target="#transcription-target-1">
                   <span class="scl-microphone"><svg width="15" style="overflow: visible" viewbox="0 0 576 700" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M576 348h-72c0 105.84-86.16 192-192 192h-48c-105.84 0-192-86.16-192-192H0c0 141.61 111.94 257.39 252 263.63v96.38H120v72h336v-72H324v-96.38C464.06 605.4 576 489.47 576 348Z"/><path d="M288 480c79.45 0 144-64.55 144-144V144C432 64.55 367.45 0 288 0S144 64.55 144 144v192c0 79.45 64.55 144 144 144zm-72-336c0-39.7 32.3-72 72-72s72 32.3 72 72v192c0 39.7-32.3 72-72 72s-72-32.3-72-72z"/></svg></span>
                   </span>
@@ -28,7 +28,7 @@
             </li>
             <li>
               <div class="scl-mobile-list-header">
-                <a class="govuk-link govuk-link--no-visited-state scl-list-header-link" href="#"><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-date-tag">5 Mar. 2025</strong><span class="scl-block-link-text">Infinity Innovations</span></a>
+                <a class="govuk-link govuk-link--no-visited-state scl-list-header-link" href="#"><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-tag scl-tag--medium scl-tag--date scl-list__date">5 Mar. 2025</strong><span class="scl-block-link-text">Infinity Innovations</span></a>
                 <button class="govuk-button scl-inline-record-button scl-ready-to-record" type="button" data-module="scl-transcription-button" data-scl-transcription-target="#transcription-target-2">
                   <span class="scl-microphone"><svg width="15" style="overflow: visible" viewbox="0 0 576 700" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M576 348h-72c0 105.84-86.16 192-192 192h-48c-105.84 0-192-86.16-192-192H0c0 141.61 111.94 257.39 252 263.63v96.38H120v72h336v-72H324v-96.38C464.06 605.4 576 489.47 576 348Z"/><path d="M288 480c79.45 0 144-64.55 144-144V144C432 64.55 367.45 0 288 0S144 64.55 144 144v192c0 79.45 64.55 144 144 144zm-72-336c0-39.7 32.3-72 72-72s72 32.3 72 72v192c0 39.7-32.3 72-72 72s-72-32.3-72-72z"/></svg></span>
                   </span>
@@ -41,7 +41,7 @@
             </li>
             <li>
               <div class="scl-mobile-list-header">
-                <a class="govuk-link govuk-link--no-visited-state scl-list-header-link" href="#"><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-date-tag">15 Mar. 2025</strong><span class="scl-block-link-text">Infinity Innovations</span></a>
+                <a class="govuk-link govuk-link--no-visited-state scl-list-header-link" href="#"><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-tag scl-tag--medium scl-tag--date scl-list__date">15 Mar. 2025</strong><span class="scl-block-link-text">Infinity Innovations</span></a>
                 <button class="govuk-button scl-inline-record-button scl-ready-to-record" type="button" data-module="scl-transcription-button" data-scl-transcription-target="#transcription-target-3">
                   <span class="scl-microphone"><svg width="15" style="overflow: visible" viewbox="0 0 576 700" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M576 348h-72c0 105.84-86.16 192-192 192h-48c-105.84 0-192-86.16-192-192H0c0 141.61 111.94 257.39 252 263.63v96.38H120v72h336v-72H324v-96.38C464.06 605.4 576 489.47 576 348Z"/><path d="M288 480c79.45 0 144-64.55 144-144V144C432 64.55 367.45 0 288 0S144 64.55 144 144v192c0 79.45 64.55 144 144 144zm-72-336c0-39.7 32.3-72 72-72s72 32.3 72 72v192c0 39.7-32.3 72-72 72s-72-32.3-72-72z"/></svg></span>
                   </span>
@@ -54,7 +54,7 @@
             </li>
             <li>
               <div class="scl-mobile-list-header">
-                <a class="govuk-link govuk-link--no-visited-state scl-list-header-link" href="#"><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-date-tag">3 Apr. 2025</strong><span class="scl-block-link-text">Apex Industries</span></a>
+                <a class="govuk-link govuk-link--no-visited-state scl-list-header-link" href="#"><strong class="govuk-tag govuk-tag--grey govuk-!-font-tabular-numbers scl-tag scl-tag--medium scl-tag--date scl-list__date">3 Apr. 2025</strong><span class="scl-block-link-text">Apex Industries</span></a>
                 <button class="govuk-button scl-inline-record-button scl-ready-to-record" type="button" data-module="scl-transcription-button" data-scl-transcription-target="#transcription-target-4">
                   <span class="scl-microphone"><svg width="15" style="overflow: visible" viewbox="0 0 576 700" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M576 348h-72c0 105.84-86.16 192-192 192h-48c-105.84 0-192-86.16-192-192H0c0 141.61 111.94 257.39 252 263.63v96.38H120v72h336v-72H324v-96.38C464.06 605.4 576 489.47 576 348Z"/><path d="M288 480c79.45 0 144-64.55 144-144V144C432 64.55 367.45 0 288 0S144 64.55 144 144v192c0 79.45 64.55 144 144 144zm-72-336c0-39.7 32.3-72 72-72s72 32.3 72 72v192c0 39.7-32.3 72-72 72s-72-32.3-72-72z"/></svg></span>
                   </span>


### PR DESCRIPTION
This was originally a refactor to more styles in BEM, but it looked good having more padding in the date tags on the front page (and consistent, padding-wise, with the security tag in the header)