### PR TITLE
fix: POST requests

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -99,6 +99,7 @@ http {
 
         location / {
             proxy_pass http://django;
+            proxy_set_header Host $http_host;
 
             expires 0;
             add_header Pragma no-cache;


### PR DESCRIPTION
The host header needed to be passed to Django to avoid getting blocked by its CSRF protection