### PR TITLE
infra: more robust terraform apply

### DIFF
--- a/infra/7-ecs-and-transcribe.tf
+++ b/infra/7-ecs-and-transcribe.tf
@@ -51,7 +51,7 @@ resource "aws_ecs_task_definition" "main" {
         },
         {
           name  = "PGPORT"
-          value = aws_db_instance.main.port
+          value = tostring(aws_db_instance.main.port)
         },
         {
           name  = "PGDATABASE"


### PR DESCRIPTION
Sometimes (although not sure why/when) terraform complained about unmarshalling the JSON when it had a number in, rather than a string.