### PR TITLE
ci: move to what is now the latest Ubuntu runner

### DIFF
--- a/.github/workflows/lint-terraform.yml
+++ b/.github/workflows/lint-terraform.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Lint Terraform
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"


### PR DESCRIPTION
The old one has gone away (or at least is in brown-out mode)