### PR TITLE
infra: ignore engine version changes

### DIFF
--- a/infra/08-rds.tf
+++ b/infra/08-rds.tf
@@ -25,6 +25,10 @@ resource "aws_db_instance" "main" {
     aws_cloudwatch_log_group.main_db_postgresql,
     aws_cloudwatch_log_group.main_db_upgrade,
   ]
+
+  lifecycle {
+    ignore_changes = ["engine_version"]
+  }
 }
 
 resource "random_password" "main_db_password" {


### PR DESCRIPTION
AWS automatically upgrades the database version