### PR TITLE
infra: fix healthcheck now everything is behind Staff SSO

### DIFF
--- a/infra/07-lb.tf
+++ b/infra/07-lb.tf
@@ -162,4 +162,9 @@ resource "aws_lb_target_group" "main" {
   port        = var.container_port
   protocol    = "HTTP"
   target_type = "ip"
+
+  # The health check is on /, which redirects to SSO since the load balance is not logged in
+  health_check {
+    matcher = "302"
+  }
 }


### PR DESCRIPTION
Maybe we should have a separate healthcheck endpoint, but for now, this I think is good enough.