### PR TITLE
build(deps): move to most recent django-staff-sso-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ django==5.1.6
     #   django-staff-sso-client
 django-extensions==3.2.3
     # via -r requirements.in
-django-staff-sso-client==4.3.0
+django-staff-sso-client==4.4.0
     # via -r requirements.in
 h11==0.14.0
     # via uvicorn


### PR DESCRIPTION
In the previous commit I accidentally didn't move to the just-released version