### PR TITLE
fix: engagements form not closing after saving

### DIFF
--- a/scl/core/static/react/features/engagement/Details.jsx
+++ b/scl/core/static/react/features/engagement/Details.jsx
@@ -17,7 +17,6 @@ const Details = ({
   setIsUpdatingDetails,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
-  const [isUpdating, setIsUpdating] = useState(false);
 
   const ENDPOINT = `/api/v1/engagement/${data.id}`;
 
@@ -30,7 +29,7 @@ const Details = ({
     );
     setEngagement(data.data);
     setIsLoading(false);
-    setIsUpdating(false);
+    setIsUpdatingDetails(false);
     showUpdateNotification("Engagement updated");
   };
 
@@ -60,7 +59,6 @@ const Details = ({
           id={data.id}
           data={engagement}
           onSubmit={onSubmit}
-          setIsUpdating={setIsUpdating}
           setIsUpdatingDetails={setIsUpdatingDetails}
         />
       )}

--- a/scl/core/views/api.py
+++ b/scl/core/views/api.py
@@ -354,7 +354,7 @@ def engagement_note_api(request, engagement_id):
     if request.method == 'PATCH':
         with reversion.create_revision():
             for d in data['notes']:
-                note = EngagementNote.objects.get(id=d.get('id'))
+                note = EngagementNote.objects.get(id=d.get('noteId'))
                 note.contents = d["contents"]
                 note.save()
 


### PR DESCRIPTION
This change fixes two things:

- API receives the correct body request payload when patching engagement notes
- Makes sure the engagement details form is closed after save