### PR TITLE
security: lock local transcription to eu-west-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ A similar flow be configured locally, but instead of involving an HTTP endpoint,
      "Statement": [{
      "Effect": "Allow",
        "Action": "transcribe:StartStreamTranscriptionWebSocket",
-       "Resource": "*"
+       "Resource": "*",
+       "Condition": {
+          "StringEquals": {
+            "aws:RequestedRegion": "eu-west-2"
+          }
+       }
      }]
    }
    ```

--- a/infra/09-ecs-and-transcribe.tf
+++ b/infra/09-ecs-and-transcribe.tf
@@ -278,7 +278,12 @@ resource "aws_iam_role_policy" "transcribe" {
         Action = [
           "transcribe:StartStreamTranscriptionWebSocket",
         ],
-        Resource = "*"
+        Resource = "*",
+        Condition = {
+          StringEquals = {
+            "aws:RequestedRegion" = "eu-west-2"
+          }
+        }
       },
     ]
   })


### PR DESCRIPTION
This changes the Terraform to enforce that the temporary credentials created for transcription in ECS can only be used to transcribe via the AWS eu-west-2 region. The version of SCL/SCIT that uses this Terraform is going away, but I suspect good to still have it locked down while it still exists, and allows the Terraform to be used as an initial template for when SCL/SCIT is deployed elsewhere.

This change also encourages that the manually created policy for transcription triggered from a local browser also only allows transcription via eu-west-2.

Note that the CSP policy in the browser already enforces that transcription can only happen via eu-west-2 endpoint, so this only changes what can happen if/when a user was particular determined to use a different endpoint via manually extracting credentials in the browser.