### PR TITLE
Add E2E Docker build target and supporting infrastructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,15 @@ USER scl
 
 CMD ["./start-dev.sh"]
 
+FROM common AS e2e
+
+COPY start-e2e.sh .
+
+ARG GIT_COMMIT
+ENV GIT_COMMIT=${GIT_COMMIT}
+USER scl
+
+CMD ["./start-e2e.sh"]
 
 FROM common AS prod
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL := /bin/bash
 
+docker-e2e = docker compose -f compose.yaml -f compose.e2e.yaml --profile e2e
+
 .PHONY: test/db/start
 test/db/start:
 	@docker run -d --rm --name scit-postgres -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword postgres:16
@@ -25,3 +27,30 @@ init:
 	cp -r node_modules/govuk-frontend/dist/govuk/assets/* scl/static/static
 	cp -r node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.* scl/static/static
 	python manage.py collectstatic
+
+# DEV
+.PHONY: dev/up
+dev/up:
+	docker compose up --build
+
+.PHONY: dev/down
+dev/down:
+	docker compose down
+
+# PROD
+.PHONY: prod/up
+prod/up:
+	docker compose --profile prod up --build
+
+.PHONY: prod/down
+prod/down:
+	docker compose down
+
+# E2E
+.PHONY: e2e/up
+e2e/up:
+	${docker-e2e} up --build
+
+.PHONY: e2e/down
+e2e/down:
+	${docker-e2e} down -v --remove-orphans

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -1,0 +1,18 @@
+name: scl-e2e
+
+services:
+  postgres:
+    volumes:
+      - scl-e2e:/var/lib/postgresql/data
+  web-dev:
+    build:
+      context: .
+      target: e2e
+    env_file: .env
+    volumes:
+      - ./start-e2e.sh:/app/start-e2e.sh
+      - ./scl/core/fixtures:/app/scl/core/fixtures
+    profiles: ["e2e"]
+
+volumes:
+    scl-e2e:

--- a/scl/core/fixtures/e2e-fixtures.json
+++ b/scl/core/fixtures/e2e-fixtures.json
@@ -1,10 +1,32 @@
 [
 {
+    "model": "reversion.revision",
+    "pk": 1,
+    "fields": {
+        "date_created": "2025-04-16T14:24:19.755Z",
+        "user": null,
+        "comment": "Initial version."
+    }
+},
+{
+    "model": "reversion.version",
+    "pk": 1,
+    "fields": {
+        "revision": 1,
+        "object_id": "1",
+        "content_type": 9,
+        "db": "default",
+        "format": "json",
+        "serialized_data": "[{\"model\": \"core.user\", \"pk\": 1, \"fields\": {\"password\": \"\", \"last_login\": null, \"is_superuser\": true, \"username\": \"20a0353f-a7d1-4851-9af8-1bcaff152b60\", \"first_name\": \"Vyvyan\", \"last_name\": \"Holland\", \"email\": \"local.user@businessandtrade.gov.uk\", \"is_staff\": true, \"is_active\": true, \"date_joined\": \"2025-04-16T14:24:18.018Z\", \"groups\": [1], \"user_permissions\": []}}]",
+        "object_repr": "Vyvyan Holland (local.user@businessandtrade.gov.uk)"
+    }
+},
+{
     "model": "core.user",
     "pk": 1,
     "fields": {
         "password": "",
-        "last_login": "2025-04-16T08:48:57Z",
+        "last_login": "2025-04-16T14:51:34.903Z",
         "is_superuser": true,
         "username": "20a0353f-a7d1-4851-9af8-1bcaff152b60",
         "first_name": "Vyvyan",

--- a/scl/core/management/commands/creategroups.py
+++ b/scl/core/management/commands/creategroups.py
@@ -8,6 +8,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         Group.objects.get_or_create(name=settings.BASIC_ACCESS_GROUP)
+        Group.objects.get_or_create(name=settings.VIEWER_ACCESS_GROUP)
         self.stdout.write(
-            self.style.SUCCESS("Successfully created the 'Basic access' group")
+            self.style.SUCCESS("Successfully created 'Basic' and 'Viewer' access groups")
         )

--- a/scl/core/views/html.py
+++ b/scl/core/views/html.py
@@ -216,8 +216,7 @@ class CompanyDetailView(DetailView, ViewerOrCompanyAccountManagerUserMixin):
                         "company_sectors": company_sectors if company_sectors else [],
                         "all_sectors": get_all_sectors(),
                         "last_updated": current_version.revision.date_created.strftime(
-                            constants.DATE_FORMAT_LONG
-                        ),
+                            constants.DATE_FORMAT_LONG) if current_version else None,
                         "global_hq_country": self.object.get_global_hq_country,
                         "turn_over": self.object.global_turnover_millions_usd,
                         "employees": employees,

--- a/scl/settings.py
+++ b/scl/settings.py
@@ -108,6 +108,7 @@ IP_FILTER_EXCLUDE_PATHS = HEALTH_CHECK_PATHS
 # Basic access group: configures BasicAccessMiddleware that requires all users to have this access
 # This allows the app itself to be quite open in terms of SSO, but access is managed within
 BASIC_ACCESS_GROUP = 'Basic access'
+VIEWER_ACCESS_GROUP = 'Viewer access'
 BASIC_ACCESS_EXCLUDE_PATHS = HEALTH_CHECK_PATHS + [
     reverse_lazy('authbroker_client:login'),
     reverse_lazy('authbroker_client:callback'),

--- a/start-e2e.sh
+++ b/start-e2e.sh
@@ -13,7 +13,7 @@ python manage.py migrate
 python manage.py createinitialrevisions
 python manage.py creategroups
 
-# Get/Create the same user that mock-sso creates, set as staff, superuser, and with Basic and Viewer access
+# Get/Create the same user that mock-sso creates, set as staff, superuser, and with Basic and Viewer access.
 python manage.py shell << EOF
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model

--- a/start-e2e.sh
+++ b/start-e2e.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+echo "Waiting for PostgreSQL"
+while ! pg_isready --quiet
+do
+    sleep 0.5
+done
+echo "PostgreSQL ready"
+echo "--- e2e ---"
+python manage.py migrate
+python manage.py createinitialrevisions
+python manage.py creategroups
+
+# Get/Create the same user that mock-sso creates, set as staff, superuser, and with Basic and Viewer access
+python manage.py shell << EOF
+from django.contrib.auth.models import Group
+from django.contrib.auth import get_user_model
+user, _ = get_user_model().objects.get_or_create(username="20a0353f-a7d1-4851-9af8-1bcaff152b60")
+user.email = "local.user@businessandtrade.gov.uk"
+user.first_name = "Vyvyan"
+user.last_name = "Holland"
+user.is_active = True
+user.is_staff = True
+user.is_superuser = True
+user.groups.add(Group.objects.get(name='Basic access'))
+user.groups.add(Group.objects.get(name='Viewer access'))
+user.save()
+EOF
+
+python manage.py loaddata scl/core/fixtures/e2e-fixtures.json
+
+exec parallel --will-cite --line-buffer --jobs 2 --halt now,done=1 ::: \
+    "python manage.py runserver 0.0.0.0:8001" \
+    "nginx -p /home/scl"


### PR DESCRIPTION
### Description
This PR introduces a dedicated Docker build target and supporting configuration to enable end-to-end (E2E) testing of the UI in a controlled environment with preloaded database fixtures.

**What's new:**
* New Docker build stage `e2e`
* New entrypoint script `start-e2e.sh` (similar to `start-dev.sh`)
* New Compose file `docker-compose.e2e.yaml`
* New Makefile targets

**Why?**

This setup makes it easy to:
* Spin up containers for realistic UI testing with known data.
* Cleanly separate E2E test configuration from development and production.
* Avoid issues with stale volumes or orphaned containers during testing.