### PR TITLE
refactor: Docker e2e setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ CMD ["./start-dev.sh"]
 
 FROM common AS e2e
 
+# Disable nginx serving of static assets, so Django serves them without collect static
+RUN sed -i 's/assets/__dummy/' /etc/nginx/nginx.conf
 COPY start-e2e.sh .
 
 ARG GIT_COMMIT

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-docker-e2e = docker compose -f compose.yaml -f compose.e2e.yaml --profile e2e
+docker-e2e = docker compose -f compose.yaml -f compose.e2e.yaml
 
 .PHONY: test/db/start
 test/db/start:

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -1,26 +1,11 @@
 name: scl-e2e
-
 services:
   postgres:
     volumes:
       - scl-e2e:/var/lib/postgresql/data
-    networks:
-      - scl-e2e
   web-dev:
     build:
       context: .
       target: e2e
-    env_file: .env
-    profiles: ["e2e"]
-    networks:
-      - scl-e2e
-  sso:
-    networks:
-      - scl-e2e
-
 volumes:
-    scl-e2e:
-
-networks:
   scl-e2e:
-    name: scl-e2e


### PR DESCRIPTION
Small refactor of our docker e2e setup.

* This commit refactors the docker compose setup to use a single network named 'scl'
which is already defined in compose.yaml. The previously defined 'scl-e2e'
network has been removed, and all services now connect to the 'scl' network.
* Removes the e2e profile
* Delegate static asset serving to Django when running our e2e test (copied from the docker dev multi-stage build ).