### PR TITLE
refactor: remove primary edit

### DIFF
--- a/scl/core/static/react/components/PageActions.jsx
+++ b/scl/core/static/react/components/PageActions.jsx
@@ -1,23 +1,12 @@
 import React from "react";
 
 const PageActions = ({
-  isEditing,
   isAddingEngagement,
-  setIsEditing,
   setIsAddingEngagement,
   showAddEngagementBtn = true,
 }) => {
   return (
     <div className="scl-page-header__actions">
-      <button
-        className={`govuk-button ${isEditing ? "govuk-button--secondary" : ""}`}
-        onClick={() => {
-          setIsEditing(!isEditing);
-          setIsAddingEngagement(false);
-        }}
-      >
-        {isEditing ? "Stop editing" : "Edit"}
-      </button>
       {showAddEngagementBtn && (
         <button
           className={`govuk-button ${
@@ -25,7 +14,6 @@ const PageActions = ({
           }`}
           onClick={() => {
             setIsAddingEngagement(!isAddingEngagement);
-            setIsEditing(false);
           }}
         >
           {isAddingEngagement ? "Cancel" : "Add engagement"}

--- a/scl/core/static/react/components/SectionActions.jsx
+++ b/scl/core/static/react/components/SectionActions.jsx
@@ -11,13 +11,16 @@ const SectionActions = ({
     <>
       <div className="govuk-!-margin-top-6">
         <button
-          className="govuk-button govuk-!-margin-right-2"
+          className="govuk-button govuk-button--secondary govuk-!-margin-right-2"
           onClick={() => setIsCreating()}
         >
           {addLabel}
         </button>
         {showEdit && (
-          <button className="govuk-button" onClick={() => setIsUpdating(false)}>
+          <button
+            className="govuk-button govuk-button--secondary"
+            onClick={() => setIsUpdating(false)}
+          >
             {editLabel}
           </button>
         )}

--- a/scl/core/static/react/features/company-briefing/CompanyDetails.jsx
+++ b/scl/core/static/react/features/company-briefing/CompanyDetails.jsx
@@ -6,8 +6,8 @@ import LoadingSpinner from "../../components/Spinner";
 
 const CompanyDetails = ({
   data,
-  isEditing,
   csrf_token,
+  isAddingEngagement,
   nonce,
   showUpdateNotification,
 }) => {
@@ -55,7 +55,7 @@ const CompanyDetails = ({
         )}
       </div>
 
-      {isEditing && isUpdating && (
+      {isUpdating && (
         <Update
           data={companyDetails}
           onSubmit={onSubmit}
@@ -63,9 +63,9 @@ const CompanyDetails = ({
           nonce={nonce}
         />
       )}
-      {isEditing && !isUpdating && (
+      {!isUpdating && !isAddingEngagement && (
         <button
-          className="govuk-button"
+          className="govuk-button govuk-button--secondary"
           onClick={() => setIsUpdating(!isUpdating)}
         >
           Edit company details

--- a/scl/core/static/react/features/company-briefing/KeyPeople.jsx
+++ b/scl/core/static/react/features/company-briefing/KeyPeople.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import ApiProxy from "../../proxy";
 import LoadingSpinner from "../../components/Spinner";
 import Update from "../../forms/key-people/Update";
@@ -9,7 +9,6 @@ import SectionActions from "../../components/SectionActions";
 const KeyPeople = ({
   id,
   csrf_token,
-  isEditing,
   keyPeople,
   showUpdateNotification,
 }) => {
@@ -63,15 +62,6 @@ const KeyPeople = ({
     }
   };
 
-  const resetFormState = () => {
-    setIsUpdating(false);
-    setIsCreating(false);
-  };
-
-  useEffect(() => {
-    resetFormState();
-  }, [isEditing]);
-
   return (
     <LoadingSpinner isLoading={isLoading}>
       <Section title="Key People">
@@ -93,10 +83,10 @@ const KeyPeople = ({
             </ul>
           )
         )}
-        {isEditing && isCreating && (
+        {isCreating && (
           <Create onSubmit={onSubmit} setIsCreating={setIsCreating} />
         )}
-        {isEditing && isUpdating && (
+        {isUpdating && (
           <Update
             id={id}
             data={people}
@@ -105,7 +95,7 @@ const KeyPeople = ({
             setIsUpdating={setIsUpdating}
           />
         )}
-        {isEditing && !isCreating && !isUpdating && (
+        {!isCreating && !isUpdating && (
           <SectionActions
             addLabel="Add people"
             editLabel="Edit people"

--- a/scl/core/static/react/features/company-briefing/Page.jsx
+++ b/scl/core/static/react/features/company-briefing/Page.jsx
@@ -17,7 +17,6 @@ import Summary from "./Summary";
 
 const Page = ({ data, id, csrf_token, nonce }) => {
   const [notificationMessage, setNotificationMessage] = useState(null);
-  const [isEditing, setIsEditing] = useState(false);
   const [isUpdated, setIsUpdated] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [engagements, setEngagements] = useState(data.engagements);
@@ -60,7 +59,7 @@ const Page = ({ data, id, csrf_token, nonce }) => {
               <CompanyDetails
                 data={data}
                 nonce={nonce}
-                isEditing={isEditing}
+                isAddingEngagement={isAddingEngagement}
                 csrf_token={csrf_token}
                 showUpdateNotification={showUpdateNotification}
               />
@@ -68,9 +67,7 @@ const Page = ({ data, id, csrf_token, nonce }) => {
             <div className="scl-page-header__one-third">
               {data.is_account_manager && (
                 <PageActions
-                  setIsEditing={setIsEditing}
                   setIsAddingEngagement={setIsAddingEngagement}
-                  isEditing={isEditing}
                   isAddingEngagement={isAddingEngagement}
                 />
               )}
@@ -89,7 +86,6 @@ const Page = ({ data, id, csrf_token, nonce }) => {
               <>
                 <Summary
                   data={data}
-                  isEditing={isEditing}
                   csrf_token={csrf_token}
                   showUpdateNotification={showUpdateNotification}
                 />
@@ -98,7 +94,6 @@ const Page = ({ data, id, csrf_token, nonce }) => {
                   id={id}
                   showUpdateNotification={showUpdateNotification}
                   csrf_token={csrf_token}
-                  isEditing={isEditing}
                   keyPeople={data.key_people}
                 />
                 {data.has_access && (
@@ -109,7 +104,6 @@ const Page = ({ data, id, csrf_token, nonce }) => {
                       title="Company Priorities"
                       emptyMessage="Currently no company priorites are assigned."
                       csrf_token={csrf_token}
-                      isEditing={isEditing}
                       companyPriorities={data.company_priorities}
                       showUpdateNotification={showUpdateNotification}
                     />
@@ -119,7 +113,6 @@ const Page = ({ data, id, csrf_token, nonce }) => {
                       insightType="hmg_priority"
                       emptyMessage="Currently no HMG priorites are assigned."
                       csrf_token={csrf_token}
-                      isEditing={isEditing}
                       companyPriorities={data.hmg_priorities}
                       showUpdateNotification={showUpdateNotification}
                     />

--- a/scl/core/static/react/features/company-briefing/Priorities.jsx
+++ b/scl/core/static/react/features/company-briefing/Priorities.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import ApiProxy from "../../proxy";
 import LoadingSpinner from "../../components/Spinner";
 import Section from "../../components/Section";
@@ -10,7 +10,6 @@ import SectionActions from "../../components/SectionActions";
 const Priorities = ({
   id,
   csrf_token,
-  isEditing,
   insightType,
   companyPriorities,
   emptyMessage,
@@ -67,15 +66,6 @@ const Priorities = ({
     }
   };
 
-  const resetFormState = () => {
-    setIsUpdating(false);
-    setIsCreating(false);
-  };
-
-  useEffect(() => {
-    resetFormState();
-  }, [isEditing]);
-
   return (
     <LoadingSpinner isLoading={isLoading}>
       <Section isPrivaliged title={title}>
@@ -95,10 +85,10 @@ const Priorities = ({
           ))
         )}
 
-        {isEditing && isCreating && (
+        {isCreating && (
           <Create onSubmit={onSubmit} setIsCreating={setIsCreating} />
         )}
-        {isEditing && isUpdating && (
+        {isUpdating && (
           <Update
             data={priorities}
             onSubmit={onSubmit}
@@ -106,10 +96,12 @@ const Priorities = ({
             setIsUpdating={setIsUpdating}
           />
         )}
-        {isEditing && !isCreating && !isUpdating && (
+        {!isCreating && !isUpdating && (
           <SectionActions
             addLabel="Add priority"
-            editLabel="Edit priority"
+            editLabel={`Edit ${
+              priorities.length > 1 ? "priorites" : "priority"
+            }`}
             showEdit={Boolean(priorities.length)}
             setIsCreating={() => setIsCreating(!isCreating)}
             setIsUpdating={() => setIsUpdating(!isUpdating)}

--- a/scl/core/static/react/features/company-briefing/Summary.jsx
+++ b/scl/core/static/react/features/company-briefing/Summary.jsx
@@ -5,7 +5,7 @@ import Update from "../../forms/summary/Update";
 import ApiProxy from "../../proxy";
 import LoadingSpinner from "../../components/Spinner";
 
-const Summary = ({ data, isEditing, csrf_token, showUpdateNotification }) => {
+const Summary = ({ data, csrf_token, showUpdateNotification }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [summary, setSummary] = useState(data.summary);
   const [isUpdating, setIsUpdating] = useState(false);
@@ -36,11 +36,11 @@ const Summary = ({ data, isEditing, csrf_token, showUpdateNotification }) => {
           !isCreating && !isUpdating && <p className="govuk-body">{summary}</p>
         )}
 
-        {isEditing && isCreating && (
+        {isCreating && (
           <Update onSubmit={onSubmit} setIsCreating={setIsCreating} />
         )}
 
-        {isEditing && isUpdating && (
+        {isUpdating && (
           <Update
             onSubmit={onSubmit}
             data={summary}
@@ -48,18 +48,18 @@ const Summary = ({ data, isEditing, csrf_token, showUpdateNotification }) => {
           />
         )}
 
-        {isEditing && !isCreating && !isUpdating && (
+        {!isCreating && !isUpdating && (
           <div className="govuk-!-margin-top-6">
             {Boolean(summary.length) ? (
               <button
-                className="govuk-button"
+                className="govuk-button govuk-button--secondary"
                 onClick={() => setIsUpdating(!isUpdating)}
               >
                 Edit summary
               </button>
             ) : (
               <button
-                className="govuk-button govuk-!-margin-right-2 govuk-!-margin-bottom-2"
+                className="govuk-button govuk-button--secondary govuk-!-margin-right-2 govuk-!-margin-bottom-2"
                 onClick={() => setIsCreating(!isCreating)}
               >
                 Add summary

--- a/scl/core/static/react/features/engagement/Details.jsx
+++ b/scl/core/static/react/features/engagement/Details.jsx
@@ -10,7 +10,6 @@ const Details = ({
   engagement,
   setEngagement,
   csrf_token,
-  isEditing,
   showUpdateNotification,
   isUpdatingDetails,
   setIsUpdatingDetails,
@@ -51,7 +50,7 @@ const Details = ({
         </div>
       )}
       {!isUpdatingDetails && <p className="govuk-body">{engagement.details}</p>}
-      {isEditing && isUpdatingDetails && (
+      {isUpdatingDetails && (
         <Update
           id={data.id}
           data={engagement}
@@ -59,10 +58,10 @@ const Details = ({
           setIsUpdatingDetails={setIsUpdatingDetails}
         />
       )}
-      {isEditing && !isUpdatingDetails && (
+      {!isUpdatingDetails && (
         <div className="govuk-!-margin-top-6">
           <button
-            className="govuk-button"
+            className="govuk-button govuk-button--secondary"
             onClick={() => setIsUpdatingDetails(true)}
           >
             Edit details

--- a/scl/core/static/react/features/engagement/Notes.jsx
+++ b/scl/core/static/react/features/engagement/Notes.jsx
@@ -17,7 +17,6 @@ import Update from "../../forms/notes/Update";
 const Notes = ({
   csrf_token,
   data,
-  isEditing,
   showUpdateNotification,
   isUpdatingNotes,
   setIsUpdatingNotes,
@@ -69,7 +68,7 @@ const Notes = ({
   }, [isCreatingNotes]);
 
   const handleOnTranscribe = async (e) => {
-    e.preventDefault()
+    e.preventDefault();
     setIsTranscribing(!isTranscribing);
   };
 
@@ -219,7 +218,7 @@ const Notes = ({
             <p className="govuk-body">You currently have no notes.</p>
           ))}
       </LoadingSpinner>
-      {isEditing && isCreatingNotes && (
+      {isCreatingNotes && (
         <Create
           onSubmit={onSubmit}
           setIsCreating={setIsCreatingNotes}
@@ -230,7 +229,7 @@ const Notes = ({
           hasFinalisedTranscription={hasFinalisedTranscription}
         />
       )}
-      {isEditing && isUpdatingNotes && (
+      {isUpdatingNotes && (
         <Update
           data={notes}
           onSubmit={onSubmit}
@@ -238,11 +237,11 @@ const Notes = ({
           setIsUpdating={setIsUpdatingNotes}
         />
       )}
-      {isEditing && !isCreatingNotes && !isUpdatingNotes && (
+      {!isCreatingNotes && !isUpdatingNotes && (
         <SectionActions
           addLabel="Add note"
-          editLabel="Edit note"
           showEdit={Boolean(notes.length)}
+          editLabel={`Edit ${notes.length > 1 ? "notes" : "note"}`}
           setIsCreating={() => setIsCreatingNotes(!isCreatingNotes)}
           setIsUpdating={() => setIsUpdatingNotes(!isUpdatingNotes)}
         />

--- a/scl/core/static/react/features/engagement/Page.jsx
+++ b/scl/core/static/react/features/engagement/Page.jsx
@@ -12,7 +12,6 @@ const Page = ({ data, csrf_token }) => {
   });
 
   const [notificationMessage, setNotificationMessage] = useState(null);
-  const [isEditing, setIsEditing] = useState(false);
   const [isUpdated, setIsUpdated] = useState(false);
   const [isUpdatingDetails, setIsUpdatingDetails] = useState(false);
   const [isUpdatingNotes, setIsUpdatingNotes] = useState(false);
@@ -49,7 +48,6 @@ const Page = ({ data, csrf_token }) => {
                 csrf_token={csrf_token}
                 engagement={engagement}
                 setEngagement={setEngagement}
-                isEditing={isEditing}
                 isUpdatingDetails={isUpdatingDetails}
                 setIsUpdatingDetails={setIsUpdatingDetails}
                 showUpdateNotification={showUpdateNotification}
@@ -58,32 +56,12 @@ const Page = ({ data, csrf_token }) => {
                 <Notes
                   csrf_token={csrf_token}
                   data={data}
-                  isEditing={isEditing}
                   isUpdatingNotes={isUpdatingNotes}
                   isCreatingNotes={isCreatingNotes}
                   setIsUpdatingNotes={setIsUpdatingNotes}
                   setIsCreatingNotes={setIsCreatingNotes}
                   showUpdateNotification={showUpdateNotification}
                 />
-              )}
-            </div>
-            <div className="scl-page-header__one-third">
-              {data.is_account_manager && (
-                <div className="scl-page-header__actions">
-                  <button
-                    className={`govuk-button ${
-                      isEditing ? "govuk-button--secondary" : ""
-                    }`}
-                    onClick={() => {
-                      setIsEditing(!isEditing);
-                      setIsUpdatingDetails(false);
-                      setIsUpdatingNotes(false);
-                      setIsCreatingNotes(false);
-                    }}
-                  >
-                    {isEditing ? "Stop editing" : "Edit"}
-                  </button>
-                </div>
               )}
             </div>
           </div>

--- a/scl/core/views/api.py
+++ b/scl/core/views/api.py
@@ -487,7 +487,7 @@ def engagement_note_api(request, engagement_id):
                 f"({request.build_absolute_uri()} from {request.headers['referer']})"
             )
 
-            notess = engagement.notes.all()
+            notes = engagement.notes.all()
 
             return JsonResponse(
                 {

--- a/scl/core/views/api.py
+++ b/scl/core/views/api.py
@@ -115,7 +115,8 @@ class CompanyAPIView(CompanyAccountManagerUserMixin, View):
             if self.data.get("title"):
                 company.name = self.data.get("title").strip()
             if self.data.get("sectors"):
-                company.sectors = [key["value"] for key in self.data.get("sectors")]
+                company.sectors = [key["value"]
+                                   for key in self.data.get("sectors")]
             if self.data.get("summary"):
                 company.summary = self.data.get("summary").strip()
             company.save()
@@ -175,7 +176,8 @@ class CompanyInsightAPIView(CompanyAccountManagerUserMixin, View):
             insight.delete()
 
             updated_insights = list(
-                self.company.insights.filter(insight_type=self.kwargs["insight_type"])
+                self.company.insights.filter(
+                    insight_type=self.kwargs["insight_type"])
             )
 
             reversion.set_user(self.request.user)
@@ -207,7 +209,8 @@ class CompanyInsightAPIView(CompanyAccountManagerUserMixin, View):
                 insight.save()
 
             updated_insights = list(
-                self.company.insights.filter(insight_type=self.kwargs["insight_type"])
+                self.company.insights.filter(
+                    insight_type=self.kwargs["insight_type"])
             )
 
             reversion.set_user(self.request.user)
@@ -241,7 +244,8 @@ class CompanyInsightAPIView(CompanyAccountManagerUserMixin, View):
             )
 
             updated_insights = list(
-                self.company.insights.filter(insight_type=self.kwargs["insight_type"])
+                self.company.insights.filter(
+                    insight_type=self.kwargs["insight_type"])
             )
 
             reversion.set_user(self.request.user)
@@ -445,6 +449,7 @@ def engagement_note_api(request, engagement_id):
         with reversion.create_revision():
             for d in data["notes"]:
                 note = EngagementNote.objects.get(id=d.get("noteId"))
+                note.created_by = request.user
                 note.contents = d["contents"]
                 note.save()
 
@@ -473,7 +478,7 @@ def engagement_note_api(request, engagement_id):
     if request.method == "POST":
         with reversion.create_revision():
             note = EngagementNote.objects.create(
-                contents=data.get("contents").strip(), engagement=engagement
+                contents=data.get("contents").strip(), engagement=engagement, created_by=request.user
             )
 
             reversion.set_user(request.user)
@@ -482,7 +487,7 @@ def engagement_note_api(request, engagement_id):
                 f"({request.build_absolute_uri()} from {request.headers['referer']})"
             )
 
-            notes = engagement.notes.all()
+            notess = engagement.notes.all()
 
             return JsonResponse(
                 {


### PR DESCRIPTION
This change:
- Removes the primary edit function for the briefing and engagements page
- Switches buttons to use secondary styles
- Fixes the notes api as we were not saving who added/edited a note