### PR TITLE
refactor: hide all form actions from all non account managers

### DIFF
--- a/scl/core/static/react/components/SectionActions.jsx
+++ b/scl/core/static/react/components/SectionActions.jsx
@@ -1,4 +1,6 @@
-import React from "react";
+import React, { useContext } from "react";
+
+import { AccountContext } from "../providers";
 
 const SectionActions = ({
   addLabel,
@@ -7,24 +9,28 @@ const SectionActions = ({
   setIsUpdating,
   setIsCreating,
 }) => {
+  const { isAccountManager } = useContext(AccountContext);
+
   return (
     <>
-      <div className="govuk-!-margin-top-6">
-        <button
-          className="govuk-button govuk-button--secondary govuk-!-margin-right-2"
-          onClick={() => setIsCreating()}
-        >
-          {addLabel}
-        </button>
-        {showEdit && (
+      {isAccountManager && (
+        <div className="govuk-!-margin-top-6">
           <button
-            className="govuk-button govuk-button--secondary"
-            onClick={() => setIsUpdating(false)}
+            className="govuk-button govuk-button--secondary govuk-!-margin-right-2"
+            onClick={() => setIsCreating()}
           >
-            {editLabel}
+            {addLabel}
           </button>
-        )}
-      </div>
+          {showEdit && (
+            <button
+              className="govuk-button govuk-button--secondary"
+              onClick={() => setIsUpdating(false)}
+            >
+              {editLabel}
+            </button>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/scl/core/static/react/features/company-briefing/CompanyDetails.jsx
+++ b/scl/core/static/react/features/company-briefing/CompanyDetails.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 
 import ApiProxy from "../../proxy";
 import Update from "../../forms/company-details/Update";
 import LoadingSpinner from "../../components/Spinner";
+
+import { AccountContext } from "../../providers";
 
 const CompanyDetails = ({
   data,
@@ -14,6 +16,8 @@ const CompanyDetails = ({
   const [isLoading, setIsLoading] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [companyDetails, setCompanyDetails] = useState(data);
+
+  const { isAccountManager } = useContext(AccountContext);
 
   const ENDPOINT = `/api/v1/company/${data.duns_number}`;
 
@@ -63,7 +67,7 @@ const CompanyDetails = ({
           nonce={nonce}
         />
       )}
-      {!isUpdating && !isAddingEngagement && (
+      {!isUpdating && !isAddingEngagement && isAccountManager && (
         <button
           className="govuk-button govuk-button--secondary"
           onClick={() => setIsUpdating(!isUpdating)}

--- a/scl/core/static/react/features/company-briefing/Summary.jsx
+++ b/scl/core/static/react/features/company-briefing/Summary.jsx
@@ -1,15 +1,19 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 
 import Section from "../../components/Section";
 import Update from "../../forms/summary/Update";
 import ApiProxy from "../../proxy";
 import LoadingSpinner from "../../components/Spinner";
 
+import { AccountContext } from "../../providers";
+
 const Summary = ({ data, csrf_token, showUpdateNotification }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [summary, setSummary] = useState(data.summary);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+
+  const { isAccountManager } = useContext(AccountContext);
 
   const ENDPOINT = `/api/v1/company/${data.duns_number}`;
 
@@ -48,25 +52,27 @@ const Summary = ({ data, csrf_token, showUpdateNotification }) => {
           />
         )}
 
-        {!isCreating && !isUpdating && (
-          <div className="govuk-!-margin-top-6">
-            {Boolean(summary.length) ? (
-              <button
-                className="govuk-button govuk-button--secondary"
-                onClick={() => setIsUpdating(!isUpdating)}
-              >
-                Edit summary
-              </button>
-            ) : (
-              <button
-                className="govuk-button govuk-button--secondary govuk-!-margin-right-2 govuk-!-margin-bottom-2"
-                onClick={() => setIsCreating(!isCreating)}
-              >
-                Add summary
-              </button>
-            )}
-          </div>
-        )}
+        {!isCreating &&
+          !isUpdating &&
+          isAccountManager && (
+            <div className="govuk-!-margin-top-6">
+              {Boolean(summary.length) ? (
+                <button
+                  className="govuk-button govuk-button--secondary"
+                  onClick={() => setIsUpdating(!isUpdating)}
+                >
+                  Edit summary
+                </button>
+              ) : (
+                <button
+                  className="govuk-button govuk-button--secondary govuk-!-margin-right-2 govuk-!-margin-bottom-2"
+                  onClick={() => setIsCreating(!isCreating)}
+                >
+                  Add summary
+                </button>
+              )}
+            </div>
+          )}
       </Section>
     </LoadingSpinner>
   );

--- a/scl/core/static/react/features/engagement/Details.jsx
+++ b/scl/core/static/react/features/engagement/Details.jsx
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 
 import ApiProxy from "../../proxy";
 
 import Update from "../../forms/engagements/Update";
 import LoadingSpinner from "../../components/Spinner";
+
+import { AccountContext } from "../../providers";
 
 const Details = ({
   data,
@@ -15,6 +17,8 @@ const Details = ({
   setIsUpdatingDetails,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
+
+  const { isAccountManager } = useContext(AccountContext);
 
   const ENDPOINT = `/api/v1/engagement/${data.id}`;
 
@@ -58,7 +62,7 @@ const Details = ({
           setIsUpdatingDetails={setIsUpdatingDetails}
         />
       )}
-      {!isUpdatingDetails && (
+      {!isUpdatingDetails && isAccountManager && (
         <div className="govuk-!-margin-top-6">
           <button
             className="govuk-button govuk-button--secondary"

--- a/scl/core/static/react/features/engagement/Page.jsx
+++ b/scl/core/static/react/features/engagement/Page.jsx
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 
 import Breadcrumb from "../../components/Breadcrumb";
 import NotificationBanner from "../../components/NotificationBanner";
 import Notes from "./Notes";
 import Details from "./Details";
+
+import { AccountContext } from "../../providers";
 
 const Page = ({ data, csrf_token }) => {
   const [engagement, setEngagement] = useState({
@@ -16,6 +18,8 @@ const Page = ({ data, csrf_token }) => {
   const [isUpdatingDetails, setIsUpdatingDetails] = useState(false);
   const [isUpdatingNotes, setIsUpdatingNotes] = useState(false);
   const [isCreatingNotes, setIsCreatingNotes] = useState(false);
+
+  const { isAccountManager } = useContext(AccountContext);
 
   const showUpdateNotification = (notificationMessage) => {
     setNotificationMessage(notificationMessage);
@@ -52,7 +56,7 @@ const Page = ({ data, csrf_token }) => {
                 setIsUpdatingDetails={setIsUpdatingDetails}
                 showUpdateNotification={showUpdateNotification}
               />
-              {data.is_account_manager && (
+              {isAccountManager && (
                 <Notes
                   csrf_token={csrf_token}
                   data={data}

--- a/scl/core/static/react/forms/notes/Create.jsx
+++ b/scl/core/static/react/forms/notes/Create.jsx
@@ -2,8 +2,9 @@ import React, { useContext } from "react";
 
 import { useForm } from "react-hook-form";
 import TranscriptButton from "../../components/TranscriptButton";
-import { FlagContext } from "../../providers";
+import { AccountContext } from "../../providers";
 import { AWS_TRANSCRIBE } from "../../constants";
+import { isFeatureFlagActive } from "../../utils";
 
 const Create = ({
   onSubmit,
@@ -22,10 +23,9 @@ const Create = ({
     formState: { errors },
   } = useForm();
 
-  const flags = useContext(FlagContext);
+  const { featureFlags } = useContext(AccountContext);
 
-  
-  const hasAwsTranscribe = flags.filter((flag) => flag["AWS_TRANSCRIBE"])[0].AWS_TRANSCRIBE;
+  const isAWSTranscribeActive = isFeatureFlagActive(featureFlags, AWS_TRANSCRIBE)
 
   setValue("contents", transcript + " " + partialTranscript);
 
@@ -63,7 +63,7 @@ const Create = ({
           >
             Save
           </button>
-          {hasAwsTranscribe && (
+          {isAWSTranscribeActive && (
             <TranscriptButton
               className="govuk-!-margin-right-4"
               onClick={handleOnTranscribe}

--- a/scl/core/static/react/mount.jsx
+++ b/scl/core/static/react/mount.jsx
@@ -1,7 +1,6 @@
-import React, { StrictMode } from "react";
+import React, { StrictMode, createContext } from "react";
 import { createRoot } from "react-dom/client";
-import { FeatureFlagContextProvider } from "./providers";
-
+import { AccountContextProvider } from "./providers";
 
 const mount = (Component, id) => {
   const rootElement = document.getElementById(id);
@@ -11,9 +10,14 @@ const mount = (Component, id) => {
 
   root.render(
     <StrictMode>
-      <FeatureFlagContextProvider flags={props.data.flags}>
+      <AccountContextProvider
+        values={{
+          featureFlags: props.data.flags,
+          isAccountManager: props.data.is_account_manager,
+        }}
+      >
         <Component {...props} />
-      </FeatureFlagContextProvider>
+      </AccountContextProvider>
     </StrictMode>
   );
 };

--- a/scl/core/static/react/providers.js
+++ b/scl/core/static/react/providers.js
@@ -1,7 +1,7 @@
 import React, { createContext } from "react";
 
-export const FlagContext = createContext();
+export const AccountContext = createContext();
 
-export const FeatureFlagContextProvider = ({ flags, children }) => (
-  <FlagContext.Provider value={flags}>{children}</FlagContext.Provider>
+export const AccountContextProvider = ({ values, children }) => (
+  <AccountContext.Provider value={values}>{children}</AccountContext.Provider>
 );

--- a/scl/core/static/react/utils.js
+++ b/scl/core/static/react/utils.js
@@ -1,0 +1,4 @@
+export const isFeatureFlagActive = (flags, key) => {
+  const obj = flags.find((obj) => Object.hasOwn(obj, key));
+  return Boolean(obj[key]);
+};


### PR DESCRIPTION
This change hides all form actions from non account managers. I have made use of the context provider to avoid prop drilling.