### PR TITLE
Refactor/rename refs to access group

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import reversion
 
+from django.conf import settings
 from django.contrib.auth.models import Group
 
 from scl.core.tests import factories
@@ -9,13 +10,13 @@ from scl.core.tests import factories
 @pytest.fixture
 @pytest.mark.django_db
 def basic_access_group():
-    return Group.objects.create(name="Basic access")
+    return Group.objects.create(name=settings.BASIC_ACCESS_GROUP)
 
 
 @pytest.fixture
 @pytest.mark.django_db
 def viewer_group():
-    return Group.objects.create(name="Viewer")
+    return Group.objects.create(name=settings.VIEWER_ACCESS_GROUP)
 
 
 @pytest.fixture

--- a/scl/core/tests/test_views_engagement.py
+++ b/scl/core/tests/test_views_engagement.py
@@ -5,17 +5,18 @@ import reversion
 from django.contrib.auth.models import Group
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.conf import settings
 
 from scl.core.tests import factories
 
 
 class EngagementPageTest(TestCase):
     def setUp(self):
-        self.group = Group.objects.create(name="Basic access")
+        self.group = Group.objects.create(name=settings.BASIC_ACCESS_GROUP)
         self.user = factories.UserFactory.create(
             is_superuser=False, groups=[self.group]
         )
-        self.viewer_group = Group.objects.create(name="Viewer")
+        self.viewer_group = Group.objects.create(name=settings.VIEWER_ACCESS_GROUP)
         self.viewer_user = factories.UserFactory.create(
             groups=[self.viewer_group, self.group]
         )

--- a/scl/core/tests/test_views_home.py
+++ b/scl/core/tests/test_views_home.py
@@ -1,6 +1,8 @@
 import re
 from datetime import datetime
 
+from django.conf import settings
+
 import pytest
 import reversion
 from bs4 import BeautifulSoup
@@ -16,7 +18,7 @@ from scl.core.views import html
 
 class HomePageTest(TestCase):
     def setUp(self):
-        self.group = Group.objects.create(name="Basic access")
+        self.group = Group.objects.create(name=settings.BASIC_ACCESS_GROUP)
         self.user = factories.UserFactory.create(
             is_superuser=False, groups=[self.group]
         )

--- a/scl/core/views/html.py
+++ b/scl/core/views/html.py
@@ -3,6 +3,7 @@ import logging
 
 from datetime import date, datetime, timedelta
 
+from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.template.response import TemplateResponse
 from django.views.generic import TemplateView, DetailView
@@ -24,7 +25,7 @@ class ViewerOrCompanyAccountManagerUserMixin(UserPassesTestMixin):
     raise_exception = True
 
     def test_func(self):
-        is_viewer = self.request.user.in_group("Viewer")
+        is_viewer = self.request.user.in_group(settings.VIEWER_ACCESS_GROUP)
         is_account_manager = self.request.user in self.company.account_manager.all()
         return is_viewer or is_account_manager
 


### PR DESCRIPTION
Currently some of the UI is showing to users when it shouldn't. This is because some refs to a user group is incorrect and needs renaming from "Viewer" to "Viewer access". To make sure we stay consistent I have reworked the string values to refer to constants in the settings.py. 