### PR TITLE
fix: pin node version to fix image build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+   "node": ">=22.0.0 <23.0.0"
+  },
   "scripts": {
     "dev": "./node_modules/.bin/webpack --config webpack.dev.js --watch",
     "build": "./node_modules/.bin/webpack build --config webpack.prod.js",


### PR DESCRIPTION
This change will fix the image build in AWS as we need to use a node version thats less than 24. I chose greater than 22 but less than 23 just to be safe.