### PR TITLE
fix/content changes for company details page

### DIFF
--- a/cypress/e2e/company-briefing.cy.js
+++ b/cypress/e2e/company-briefing.cy.js
@@ -30,12 +30,7 @@ describe("Company Briefing page", () => {
       "be.visible"
     );
 
-    cy.assertCompanyBriefingSection("Summary", {
-      content: "Currently this company has no summary.",
-      buttonName: "Add summary",
-    });
-
-    cy.assertCompanyBriefingSection("Key Facts", {
+    cy.assertCompanyBriefingSection("Summary and key facts", {
       content: [
         "Headquartered in Canada",
         "Has a global turnover of $1000000000",
@@ -43,19 +38,19 @@ describe("Company Briefing page", () => {
       ],
     });
 
-    cy.assertCompanyBriefingSection("Key People", {
+    cy.assertCompanyBriefingSection("Key people in this company", {
       content: "Currently no key people are assigned.",
       buttonName: "Add people",
     });
 
-    cy.assertCompanyBriefingSection("Company Priorities", {
+    cy.assertCompanyBriefingSection("Company priorities for HMG engagement", {
       content: "Currently no company priorites are assigned.",
       hasPrivilegedTag: true,
       buttonName: "Add priority",
     });
 
-    cy.assertCompanyBriefingSection("Government Priorities", {
-      content: "Currently no Government Priorities are assigned.",
+    cy.assertCompanyBriefingSection("HMG priorities for engagement", {
+      content: "Currently no government priorities are assigned.",
       buttonName: "Add priority",
     });
 
@@ -64,7 +59,7 @@ describe("Company Briefing page", () => {
       hasPrivilegedTag: true,
     });
 
-    cy.assertCompanyBriefingSection("People assigned to this company", {
+    cy.assertCompanyBriefingSection("Account managers", {
       content: "Vyvyan Holland",
       links: [
         {
@@ -75,16 +70,15 @@ describe("Company Briefing page", () => {
     });
 
     cy.assertCompanyBriefingSectionOrder([
-      "Summary",
-      "Key Facts",
-      "Key People",
-      "Company Priorities",
-      "Government Priorities",
+      "Summary and key facts",
+      "Key people in this company",
+      "Company priorities for HMG engagement",
+      "HMG priorities for engagement",
     ]);
 
     cy.assertCompanyBriefingSectionOrder([
       "Engagements",
-      "People assigned to this company",
+      "Account managers",
     ]);
   });
 });

--- a/cypress/e2e/company-briefing.cy.js
+++ b/cypress/e2e/company-briefing.cy.js
@@ -9,7 +9,6 @@ describe("Company Briefing page", () => {
   });
 
   it("should have all the elements on the page", () => {
-
     cy.visit(`/company-briefing/${company.duns_number}`);
 
     cy.findByRole("heading", {
@@ -76,10 +75,7 @@ describe("Company Briefing page", () => {
       "HMG priorities for engagement",
     ]);
 
-    cy.assertCompanyBriefingSectionOrder([
-      "Engagements",
-      "Account managers",
-    ]);
+    cy.assertCompanyBriefingSectionOrder(["Engagements", "Account managers"]);
   });
 });
 

--- a/scl/core/static/react/components/Section.jsx
+++ b/scl/core/static/react/components/Section.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 
-const Section = ({ children, title, className = '' }) => (
+const Section = ({ children, title, className = '', caption='', captionStyle={color: "#505A5F", marginBottom: '20px'}}) => (
   <section className={`section ${className}`}>
-    <h2 className="govuk-heading-m">{title}</h2>
+    <h2 className="govuk-heading-m" style={{marginBottom: '15px'}}>{title}</h2>
+    {caption ? <p className="govuk-body" style={captionStyle}>{caption}</p> : <></>}
     {children}
   </section>
 );

--- a/scl/core/static/react/components/Section.jsx
+++ b/scl/core/static/react/components/Section.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Section = ({ children, title, className = '', caption='', captionStyle={color: "#505A5F", marginBottom: '20px'}}) => (
+const Section = ({ children, title, className = '', caption='', captionStyle={color: '#505A5F', marginBottom: '20px'}}) => (
   <section className={`section ${className}`}>
     <h2 className="govuk-heading-m" style={{marginBottom: '15px'}}>{title}</h2>
     {caption ? <p className="govuk-body" style={captionStyle}>{caption}</p> : <></>}

--- a/scl/core/static/react/components/Section.jsx
+++ b/scl/core/static/react/components/Section.jsx
@@ -1,9 +1,19 @@
 import React from "react";
 
-const Section = ({ children, title, className = '', caption='', captionStyle={color: '#505A5F', marginBottom: '20px'}}) => (
+const Section = ({
+  children,
+  title,
+  className = "",
+  caption = "",
+  captionStyle = { color: "#505A5F", marginBottom: "20px" },
+}) => (
   <section className={`section ${className}`}>
-    <h2 className="govuk-heading-m" style={{marginBottom: '15px'}}>{title}</h2>
-    {caption ? <p className="govuk-body" style={captionStyle}>{caption}</p> : <></>}
+    <h2 className="govuk-heading-m govuk-!-margin-bottom-4">{title}</h2>
+    {caption && (
+      <p className="govuk-body" style={captionStyle}>
+        {caption}
+      </p>
+    )}
     {children}
   </section>
 );

--- a/scl/core/static/react/features/company-briefing/AccountManagers.jsx
+++ b/scl/core/static/react/features/company-briefing/AccountManagers.jsx
@@ -4,7 +4,9 @@ import Section from "../../components/Section";
 const AccountManagers = ({ accountManagers }) => (
   <Section
     className="govuk-!-display-none-print"
-    title="People assigned to this company"
+    caption="Only account managers can add or edit this company's information."
+    captionStyle={{ color: "#505A5F", marginBottom: "15px" }}
+    title="Account managers"
   >
     {accountManagers.length ? (
       <>

--- a/scl/core/static/react/features/company-briefing/KeyFacts.jsx
+++ b/scl/core/static/react/features/company-briefing/KeyFacts.jsx
@@ -4,9 +4,7 @@ import Section from "../../components/Section";
 const KeyFacts = ({ data }) => {
   return (
     <>
-      {!data.global_hq_country && !data.turn_over && !data.employees ? (
-        <></>
-      ) : (
+      {data.global_hq_country && data.turn_over && data.employees && (
         <ul className="govuk-list govuk-list--bullet scl-key-people-list">
           {data.global_hq_country && (
             <li className="scl-key-people-list__item">

--- a/scl/core/static/react/features/company-briefing/KeyFacts.jsx
+++ b/scl/core/static/react/features/company-briefing/KeyFacts.jsx
@@ -3,9 +3,9 @@ import Section from "../../components/Section";
 
 const KeyFacts = ({ data }) => {
   return (
-    <Section title="Key Facts">
+    <>
       {!data.global_hq_country && !data.turn_over && !data.employees ? (
-        <p className="govuk-body">Currently there are no key facts.</p>
+        <></>
       ) : (
         <ul className="govuk-list govuk-list--bullet scl-key-people-list">
           {data.global_hq_country && (
@@ -25,7 +25,7 @@ const KeyFacts = ({ data }) => {
           )}
         </ul>
       )}
-    </Section>
+    </>
   );
 };
 

--- a/scl/core/static/react/features/company-briefing/KeyPeople.jsx
+++ b/scl/core/static/react/features/company-briefing/KeyPeople.jsx
@@ -89,7 +89,7 @@ const KeyPeople = ({ id, csrf_token, keyPeople }) => {
 
   return (
     <LoadingSpinner isLoading={isLoading}>
-      <Section title="Key People">
+      <Section title="Key People in this company">
         <NotificationBanner
           message={notification?.message}
           status={notification?.status}

--- a/scl/core/static/react/features/company-briefing/KeyPeople.jsx
+++ b/scl/core/static/react/features/company-briefing/KeyPeople.jsx
@@ -89,7 +89,7 @@ const KeyPeople = ({ id, csrf_token, keyPeople }) => {
 
   return (
     <LoadingSpinner isLoading={isLoading}>
-      <Section title="Key People in this company">
+      <Section title="Key people in this company">
         <NotificationBanner
           message={notification?.message}
           status={notification?.status}

--- a/scl/core/static/react/features/company-briefing/Page.jsx
+++ b/scl/core/static/react/features/company-briefing/Page.jsx
@@ -4,7 +4,6 @@ import PageActions from "../../components/PageActions";
 import Breadcrumb from "../../components/Breadcrumb";
 
 import KeyPeople from "./KeyPeople";
-import KeyFacts from "./KeyFacts";
 import Priorities from "./Priorities";
 import CompanyDetails from "./CompanyDetails";
 import Engagements from "./Engagements";
@@ -82,7 +81,6 @@ const Page = ({ data, id, csrf_token, nonce }) => {
               }`}
             >
               <Summary data={data} csrf_token={csrf_token} />
-              <KeyFacts data={data} />
               <KeyPeople
                 id={id}
                 csrf_token={csrf_token}
@@ -93,16 +91,18 @@ const Page = ({ data, id, csrf_token, nonce }) => {
                   <Priorities
                     id={id}
                     insightType="company_priority"
-                    title="Company Priorities"
+                    caption="Account managers can enter what the company is lobbying for, relevant issues or policy concerns."
+                    title="Company priorities for HMG engagement"
                     emptyMessage="Currently no company priorites are assigned."
                     csrf_token={csrf_token}
                     companyPriorities={data.company_priorities}
                   />
                   <Priorities
                     id={id}
-                    title="Government Priorities"
+                    caption="Account managers can enter how this company can support government priorities, highlight opoortunities or share useful department-specific insights."
+                    title="HMG priorities for engagement"
                     insightType="hmg_priority"
-                    emptyMessage="Currently no Government Priorities are assigned."
+                    emptyMessage="Currently no government priorities are assigned."
                     csrf_token={csrf_token}
                     companyPriorities={data.hmg_priorities}
                   />

--- a/scl/core/static/react/features/company-briefing/Priorities.jsx
+++ b/scl/core/static/react/features/company-briefing/Priorities.jsx
@@ -15,6 +15,7 @@ const Priorities = ({
   companyPriorities,
   emptyMessage,
   title,
+  caption,
 }) => {
   const [priorities, setPriorities] = useState(companyPriorities);
   const [isLoading, setIsLoading] = useState(false);
@@ -85,7 +86,7 @@ const Priorities = ({
 
       if (status == 200) {
         setPriorities(data.data);
-        setNotification({ message: "Priortiy updated"});
+        setNotification({ message: "Priortiy updated" });
       } else {
         setNotification({
           message: `Status ${status}: ${data.message || data.error}`,
@@ -97,7 +98,7 @@ const Priorities = ({
 
   return (
     <LoadingSpinner isLoading={isLoading}>
-      <Section title={title}>
+      <Section caption={caption} title={title}>
         <NotificationBanner
           message={notification?.message}
           status={notification?.status}

--- a/scl/core/static/react/features/company-briefing/Summary.jsx
+++ b/scl/core/static/react/features/company-briefing/Summary.jsx
@@ -1,48 +1,14 @@
-import React, { useState, useContext } from "react";
+import React, { useState } from "react";
 
 import Section from "../../components/Section";
-import Update from "../../forms/summary/Update";
-import ApiProxy from "../../proxy";
 import LoadingSpinner from "../../components/Spinner";
 import NotificationBanner from "../../components/NotificationBanner";
 import KeyFacts from "./KeyFacts";
-
-import { GlobalContext } from "../../providers";
 
 const Summary = ({ data, csrf_token }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [summary, setSummary] = useState(data.summary);
   const [notification, setNotification] = useState(null);
-  const [isUpdating, setIsUpdating] = useState(false);
-  const [isCreating, setIsCreating] = useState(false);
-
-  const { isAccountManager } = useContext(GlobalContext);
-
-  const ENDPOINT = `/api/v1/company/${data.duns_number}`;
-
-  const onSubmit = async (payload) => {
-    setIsLoading(true);
-
-    const { data, status } = await ApiProxy.update(
-      ENDPOINT,
-      payload,
-      csrf_token
-    );
-
-    setIsLoading(false);
-    setIsCreating(false);
-    setIsUpdating(false);
-
-    if (status === 200) {
-      setSummary(data.data.summary);
-      setNotification({ message: "Summary updated" });
-    } else {
-      setNotification({
-        message: `Status ${status}: ${data.message || data.error}`,
-        status: "warning",
-      });
-    }
-  };
 
   return (
     <LoadingSpinner isLoading={isLoading}>
@@ -59,7 +25,7 @@ const Summary = ({ data, csrf_token }) => {
             Currently there is no summary for this company.
           </p>
         ) : (
-          !isCreating && !isUpdating && <p className="govuk-body">{summary}</p>
+         <p className="govuk-body">{summary}</p>
         )}
         <KeyFacts data={data} />
       </Section>

--- a/scl/core/static/react/features/company-briefing/Summary.jsx
+++ b/scl/core/static/react/features/company-briefing/Summary.jsx
@@ -54,7 +54,7 @@ const Summary = ({ data, csrf_token }) => {
           message={notification?.message}
           status={notification?.status}
         />
-        {!summary ? (
+        {!summary && data.global_hq_country && !data.turn_over && !data.employees ? (
           <p className="govuk-body">
             Currently there is no summary for this company.
           </p>

--- a/scl/core/static/react/features/company-briefing/Summary.jsx
+++ b/scl/core/static/react/features/company-briefing/Summary.jsx
@@ -5,6 +5,7 @@ import Update from "../../forms/summary/Update";
 import ApiProxy from "../../proxy";
 import LoadingSpinner from "../../components/Spinner";
 import NotificationBanner from "../../components/NotificationBanner";
+import KeyFacts from "./KeyFacts";
 
 import { GlobalContext } from "../../providers";
 
@@ -45,48 +46,22 @@ const Summary = ({ data, csrf_token }) => {
 
   return (
     <LoadingSpinner isLoading={isLoading}>
-      <Section title="Summary">
+      <Section
+        caption="This publicly available information provides an overview of the company."
+        title="Summary and key facts"
+      >
         <NotificationBanner
           message={notification?.message}
           status={notification?.status}
         />
         {!summary ? (
-          <p className="govuk-body">Currently this company has no summary.</p>
+          <p className="govuk-body">
+            Currently there is no summary for this company.
+          </p>
         ) : (
           !isCreating && !isUpdating && <p className="govuk-body">{summary}</p>
         )}
-
-        {isCreating && (
-          <Update onSubmit={onSubmit} setIsCreating={setIsCreating} />
-        )}
-
-        {isUpdating && (
-          <Update
-            onSubmit={onSubmit}
-            data={summary}
-            setIsCreating={setIsUpdating}
-          />
-        )}
-
-        {!isCreating && !isUpdating && isAccountManager && (
-          <div className="govuk-!-margin-top-6">
-            {Boolean(summary.length) ? (
-              <button
-                className="govuk-button govuk-button--secondary"
-                onClick={() => setIsUpdating(!isUpdating)}
-              >
-                Edit summary
-              </button>
-            ) : (
-              <button
-                className="govuk-button govuk-button--secondary govuk-!-margin-right-2 govuk-!-margin-bottom-2"
-                onClick={() => setIsCreating(!isCreating)}
-              >
-                Add summary
-              </button>
-            )}
-          </div>
-        )}
+        <KeyFacts data={data} />
       </Section>
     </LoadingSpinner>
   );

--- a/scl/core/tests/test_api.py
+++ b/scl/core/tests/test_api.py
@@ -73,7 +73,6 @@ def test_company_insight_api_authorisation(
 @pytest.mark.django_db
 def test_company_api_patch(viewer_user_client, company_acc_manager):
     data = {
-        "summary": "Lorem ipsum dolor sit amet",
         "title": "Company name",
         "sectors": [
             {"value": "SL0001", "label": "Advanced engineering"},
@@ -89,7 +88,6 @@ def test_company_api_patch(viewer_user_client, company_acc_manager):
     assert response.status_code == 200
     response_data = json.loads(response.content)
     assert response_data["data"]["title"] == "Company name"
-    assert response_data["data"]["summary"] == "Lorem ipsum dolor sit amet"
     assert response_data["data"]["company_sectors"] == [
         {"label": "Advanced engineering", "value": "SL0001"},
         {"label": "Aerospace", "value": "SL0011"},

--- a/scl/core/views/api.py
+++ b/scl/core/views/api.py
@@ -153,8 +153,6 @@ class CompanyAPIView(CompanyAccountManagerUserMixin, View):
                 company.name = self.data.get("title").strip()
             if self.data.get("sectors"):
                 company.sectors = [key["value"] for key in self.data.get("sectors")]
-            if self.data.get("summary"):
-                company.summary = self.data.get("summary").strip()
             company.save()
 
             updated_company = Company.objects.get(
@@ -173,7 +171,6 @@ class CompanyAPIView(CompanyAccountManagerUserMixin, View):
                     "duns_number": updated_company.duns_number,
                     "company_sectors": get_company_sectors(updated_company),
                     "all_sectors": get_all_sectors(),
-                    "summary": updated_company.summary,
                     "last_updated": updated_company.last_updated.strftime(
                         "%B %d, %Y, %H:%M"
                     ),


### PR DESCRIPTION
content changes/styling based on UCD feedback:
- content changes (e2e and static/)
- added an arg to `components/Section` so that it can also render a caption-like paragraph tag to add to the heading
- Merge KeyFacts & Summary together - removed the Edit Summary button as well. Apparently this isn't needed so have removed the PATCH route for summary as well.