### PR TITLE
fix: only surface notes from the request user

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -102,7 +102,7 @@ def company_acc_manager(viewer_user):
             3, engagement=engagements[0], created_by=acc_manager.account_manager
         )
         factories.EngagementNoteFactory.create_batch(
-            2, engagement=engagements[1], created_by=viewer_user
+            2, engagement=engagements[0], created_by=viewer_user
         )
 
     return company
@@ -110,7 +110,7 @@ def company_acc_manager(viewer_user):
 
 @pytest.fixture
 @pytest.mark.django_db
-def company_not_acc_manager(viewer_user):
+def company_not_acc_manager(viewer_user, super_access_user):
     """
     Company with an account manager that is not the viewer_user.
     """
@@ -134,6 +134,9 @@ def company_not_acc_manager(viewer_user):
         engagements = factories.EngagementFactory.create_batch(4, company=company)
         factories.EngagementNoteFactory.create_batch(
             3, engagement=engagements[0], created_by=acc_manager.account_manager
+        )
+        factories.EngagementNoteFactory.create_batch(
+            2, engagement=engagements[0], created_by=super_access_user
         )
 
     return company

--- a/scl/core/views/api.py
+++ b/scl/core/views/api.py
@@ -699,6 +699,10 @@ class EngagementNoteAPIView(CompanyAccountManagerUserMixin, View):
         logger.info("Requesting enagement with id: %s", self.kwargs["engagement_id"])
         return Engagement.objects.get(id=self.kwargs["engagement_id"])
 
+    @property
+    def user_notes(self):
+        return self.engagement.notes.filter(created_by=self.request.user)
+
     def patch(self, *args, **kwargs):
         with reversion.create_revision():
             for d in self.data["notes"]:
@@ -707,14 +711,11 @@ class EngagementNoteAPIView(CompanyAccountManagerUserMixin, View):
                 note.contents = d["contents"]
                 note.save()
 
-            updated_notes = self.engagement.notes.all()
-
             reversion.set_user(self.request.user)
             reversion.set_comment(
                 "Note updated"
                 f"({self.request.build_absolute_uri()} from {self.request.headers.get('referer', '')})"
             )
-
         response = JsonResponse(
             {
                 "data": [
@@ -722,7 +723,7 @@ class EngagementNoteAPIView(CompanyAccountManagerUserMixin, View):
                         "noteId": str(note.id),
                         "contents": note.contents,
                     }
-                    for note in updated_notes
+                    for note in self.user_notes
                 ],
             },
             status=200,
@@ -749,7 +750,6 @@ class EngagementNoteAPIView(CompanyAccountManagerUserMixin, View):
                 f"({self.request.build_absolute_uri()} from {self.request.headers.get('referer', '')})"
             )
 
-            notes = self.engagement.notes.all()
         response = JsonResponse(
             {
                 "data": [
@@ -757,7 +757,7 @@ class EngagementNoteAPIView(CompanyAccountManagerUserMixin, View):
                         "noteId": str(note.id),
                         "contents": note.contents,
                     }
-                    for note in notes
+                    for note in self.user_notes
                 ],
             },
             status=200,
@@ -781,7 +781,6 @@ class EngagementNoteAPIView(CompanyAccountManagerUserMixin, View):
                 f"({self.request.build_absolute_uri()} from {self.request.headers.get('referer', '')})"
             )
 
-            notes = self.engagement.notes.all()
         response = JsonResponse(
             {
                 "data": [
@@ -789,7 +788,7 @@ class EngagementNoteAPIView(CompanyAccountManagerUserMixin, View):
                         "noteId": str(note.id),
                         "contents": note.contents,
                     }
-                    for note in notes
+                    for note in self.user_notes
                 ],
             },
             status=200,


### PR DESCRIPTION
This change makes sure we are only surface engagement notes to the request user. Although account managers can see other account managers engagements they should see each others notes.