### PR TITLE
fix return attendees after new engagement created

### DIFF
--- a/cypress/e2e/add-engagement.cy.js
+++ b/cypress/e2e/add-engagement.cy.js
@@ -1,21 +1,5 @@
 import { COMPANIES } from "./constants";
 
-const assertEngagementList = (expectedItems = []) => {
-  cy.findByRole("heading", { name: "Engagements" })
-    .closest("section")
-    .within(() => {
-      expectedItems.forEach((item, index) => {
-        cy.findAllByRole("listitem")
-          .eq(index)
-          .within(() => {
-            cy.findByRole("link").within(() => {
-              cy.findByText(item.text).should("exist");
-            });
-          });
-      });
-    });
-};
-
 const assertViewAllEngagementsLink = (company) => {
   cy.findByRole("heading", { name: "Engagements" })
     .closest("section")
@@ -32,9 +16,9 @@ const assertViewAllEngagementsLink = (company) => {
 
 const assertEmptyNotes = () => {
   cy.findByRole("heading", { name: "Business intelligence", level: 2 });
-  cy.findByText(
-    "Only you can add or view information in this section."
-  ).should("be.visible");
+  cy.findByText("Only you can add or view information in this section.").should(
+    "be.visible"
+  );
   cy.findByText(
     "This engagement has no business intelligence recorded."
   ).should("be.visible");
@@ -151,9 +135,23 @@ describe("Add/edit an engagement", () => {
         title: "Saved",
         heading: "Engagement added",
       });
-      assertEngagementList([
-        { date: "February 01 2030", text: "My engagement tite" },
-      ]);
+
+      cy.findByRole("heading", { name: "Engagements", level: 2 })
+        .closest("section")
+        .within(() => {
+          cy.findByRole("link", {
+            name: "My engagement tite",
+          }).should("be.visible");
+          cy.findByText("Date")
+            .should("be.visible")
+            .next()
+            .findByText("February 01 2030");
+          cy.findByText("Attendees")
+            .should("be.visible")
+            .next()
+            .findByText("Cara, Louise, Jack, Jill, Bob, Sarah");
+        });
+
       assertViewAllEngagementsLink(COMPANIES.testing_corp);
       cy.findByTestId("engagements").within(() => {
         cy.findByRole("link", {

--- a/scl/core/tests/test_api.py
+++ b/scl/core/tests/test_api.py
@@ -971,6 +971,15 @@ def test_company_engagement_api_post(
         assert "Lorem ipsum dolor sit amet" in [
             d["agenda"] for d in response_data["data"]
         ]
+        assert "Letter" in [d["engagement_type"] for d in response_data["data"]]
+        assert ["Louise", "Jenny"] in [d["ministers"] for d in response_data["data"]]
+        assert ["Bob", "Sarah"] in [d["civil_servants"] for d in response_data["data"]]
+        assert ["Jack", "Jill"] in [
+            d["company_representatives"] for d in response_data["data"]
+        ]
+        assert ["Louise", "Jenny", "Bob", "Sarah", "Jack", "Jill"] in [
+            d["all_attendees"] for d in response_data["data"]
+        ]
         assert "January 25 2040" in [d["date"] for d in response_data["data"]]
     assert company_acc_manager.engagements.count() == 6
 

--- a/scl/core/views/api.py
+++ b/scl/core/views/api.py
@@ -654,6 +654,7 @@ class CompanyEngagementAPIView(CompanyAccountManagerUserMixin, View):
                         "company_representatives": engagement.company_representatives,
                         "civil_servants": engagement.civil_servants,
                         "ministers": engagement.ministers,
+                        "all_attendees": engagement.all_attendees,
                         "engagement_type": engagement.get_engagement_type_display(),
                         "engagement_type_colour": engagement.engagement_type_colour,
                     }


### PR DESCRIPTION
This change returns "all attendees" as a result of a successful POST request when adding a new engagement. Without this you will need to reload the page before you see the updated attendees in the right column of the company briefing page.